### PR TITLE
Update icon for ClipboardIconButton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Export new request methods: get, getText, parseText
+- Update the icon for ClipboardIconButton
 
 ## 0.0.20
 

--- a/components/icons/CopyIcon.tsx
+++ b/components/icons/CopyIcon.tsx
@@ -23,11 +23,11 @@ import Icon, { IconProps } from './Icon';
 export default function CopyIcon({ className, fill = 'currentColor', size }: IconProps) {
   return (
     <Icon className={className} size={size}>
-      <path
-        d="M11.002 1.002h-8a.945.945 0 0 0-1 1v9h1v-9h8zm-6 2a.945.945 0 0 0-1 1v10c0 .733.267 1 1 1h8c.733 0 1-.267 1-1v-10c0-.733-.267-1-1-1zm0 11h8v-10h-8z"
-        fillRule="evenodd"
-        style={{ fill }}
-      />
+      <g fill={fill} fillRule="nonzero">
+        <path d="M2.931 15.005V3H2v13h9v-.995z" />
+        <path d="M10 4.015h3V14H4V1h6v3.015zM9 8V6H8v2H6v1h2v2h1V9h2V8H9z" />
+        <path d="M11 1v2h2a2.151 2.151 0 0 0-2-2z" />
+      </g>
     </Icon>
   );
 }


### PR DESCRIPTION
Needed for MMF-1781, as a starting point to revamp the copy icon for SonarCloud. See icons at the end of points 1 and 2 in this mockup screen:

![FirstAnalysisTutorial_3 2-BitBucket--create-pipeline-step2](https://user-images.githubusercontent.com/49895321/62950772-07f46e80-bde9-11e9-97de-4fb87c5b4636.png)

See: 

* https://jira.sonarsource.com/browse/MMF-1781

**Checklist**

* [x] Write/update ITs
* [ ] Functional validation
* [ ] Documentation update
* [x] Update changelog