### PR TITLE
SONAR-12414 Add new ClickEventBoundary to prevent click event bubbling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix positioning logic in ScreenPositionFixer
 - SONAR-12380 A Tooltip should be flipped if too close to the viewport's edge
+- SONAR-12414 Add new ClickEventBoundary component, to support catching click events and preventing their bubbling up the component tree
 
 ## 0.0.21
 

--- a/components/controls/ClickEventBoundary.tsx
+++ b/components/controls/ClickEventBoundary.tsx
@@ -1,0 +1,35 @@
+/*
+ * Sonar UI Common
+ * Copyright (C) 2019-2019 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+import * as React from 'react';
+
+export interface ClickEventBoundaryProps {
+  children: React.ReactElement;
+}
+
+export default function ClickEventBoundary({ children }: ClickEventBoundaryProps) {
+  return React.cloneElement(children, {
+    onClick: (e: React.SyntheticEvent<MouseEvent>) => {
+      e.stopPropagation();
+      if (typeof children.props.onClick === 'function') {
+        children.props.onClick(e);
+      }
+    }
+  });
+}

--- a/components/controls/__tests__/ClickEventBoundary-test.tsx
+++ b/components/controls/__tests__/ClickEventBoundary-test.tsx
@@ -1,0 +1,49 @@
+/*
+ * Sonar UI Common
+ * Copyright (C) 2019-2019 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+import { mount } from 'enzyme';
+import * as React from 'react';
+import ClickEventBoundary from '../ClickEventBoundary';
+
+it('should render correctly', () => {
+  expect(shallowRender()).toMatchSnapshot();
+});
+
+it('should correctly capture a click event', () => {
+  const parentOnClick = jest.fn();
+  const childOnClick = jest.fn();
+  const wrapper = shallowRender({ onClick: parentOnClick }, { onClick: childOnClick });
+  // Don't use our click() helper, so we make sure the bubbling works correctly.
+  wrapper.find('button').simulate('click');
+  expect(childOnClick).toBeCalled();
+  expect(parentOnClick).not.toBeCalled();
+});
+
+function shallowRender(parentProps = {}, childProps = {}) {
+  // We need to mount in order to support event bubbling.
+  return mount(
+    <div {...parentProps}>
+      <ClickEventBoundary>
+        <button type="button" {...childProps}>
+          Click me
+        </button>
+      </ClickEventBoundary>
+    </div>
+  );
+}

--- a/components/controls/__tests__/__snapshots__/ClickEventBoundary-test.tsx.snap
+++ b/components/controls/__tests__/__snapshots__/ClickEventBoundary-test.tsx.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render correctly 1`] = `
+<div>
+  <ClickEventBoundary>
+    <button
+      onClick={[Function]}
+      type="button"
+    >
+      Click me
+    </button>
+  </ClickEventBoundary>
+</div>
+`;


### PR DESCRIPTION
See:

* https://jira.sonarsource.com/browse/SONAR-12414
  In issues, when we interact with text inside a dropdown (like the changelog, or the comments), selecting text, and releasing the mouse button, will open the issue. This new component serves as a "boundary" after which a click event cannot bubble further.
  See https://github.com/SonarSource/sonar-enterprise/pull/2025

**Checklist**

* [ ] Write/update ITs
* [x] Functional validation
* [ ] ~Documentation update~
* [x] Update changelog
