### PR TITLE
SONAR-12372 Fix Radio preventing a modal from closing on hitting Esc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- SONAR-12372 Fix Radio preventing a Modal from closing using the Esc key
+
 ## 0.0.22
 
 - Fix positioning logic in ScreenPositionFixer

--- a/components/controls/Radio.tsx
+++ b/components/controls/Radio.tsx
@@ -29,9 +29,7 @@ interface Props {
 }
 
 export default class Radio extends React.PureComponent<Props> {
-  handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
-    event.preventDefault();
-    event.currentTarget.blur();
+  handleClick = () => {
     this.props.onCheck(this.props.value);
   };
 


### PR DESCRIPTION
See:

* https://jira.sonarsource.com/browse/SONAR-12372
  If a Modal contains Radio buttons (see "Add Condition" modal under Quality Gates), you can no longer close it using the Esc key (confirmed in FF and Chrome, on macOS). For some reason, the way we `blur()` prevents the keydown event from firing. We don't really need it here, so I just removed the whole event handling altogether.
  See https://github.com/SonarSource/sonar-enterprise/pull/2025

**Checklist**

* [ ] ~Write/update ITs~
* [x] Functional validation
* [ ] ~Documentation update~
* [x] Update changelog
