### PR TITLE
Move billing extension into the core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 0.0.26
+
+- Expose defaultFilterOptions from react-select
+
 ## 0.0.25
 
 - Fix jest-styled-component import

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ It will provide syntax highlighting, quick-fix and intellisense.
 
 1. If everything is green, QG and travis jobs
 2. Bump versions in `package.json`
-3. `yarn` to update the `yarn.lock` file
+3. `yarn` to update the `yarn.lock` file if needed
 4. Update the [changelog](./CHANGELOG.md) (leave the `Unreleased` part which will be filled for the next version)
 5. `yarn package` to create the package to be published
 6. `yarn publish ./build/dist/sonar-ui-common-x.y.z.tgz` to actually publish it to npm registry (you might want to check your .npmrc file to make sure you are not targeting repox)

--- a/components/controls/Select.tsx
+++ b/components/controls/Select.tsx
@@ -18,10 +18,19 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 import * as React from 'react';
-import { ReactAsyncSelectProps, ReactCreatableSelectProps, ReactSelectProps } from 'react-select';
+import {
+  defaultFilterOptions as reactSelectDefaultFilterOptions,
+  ReactAsyncSelectProps,
+  ReactCreatableSelectProps,
+  ReactSelectProps
+} from 'react-select';
 import { lazyLoad } from '../lazyLoad';
 import { ClearButton } from './buttons';
 import './Select.css';
+
+declare module 'react-select' {
+  export function defaultFilterOptions(...args: any[]): any;
+}
 
 const ReactSelectLib = import('react-select');
 const ReactSelect = lazyLoad(() => ReactSelectLib);
@@ -46,6 +55,8 @@ export default function Select({ innerRef, ...props }: WithInnerRef & ReactSelec
     <ReactSelectAny {...props} clearRenderer={renderInput} clearable={clearable} ref={innerRef} />
   );
 }
+
+export const defaultFilterOptions = reactSelectDefaultFilterOptions;
 
 export function Creatable(props: ReactCreatableSelectProps) {
   // ReactSelect doesn't declare `clearRenderer` prop

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sonar-ui-common",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "description": "Common UI lib for SonarQube and SonarCloud",
   "repository": "SonarSource/sonar-ui-common",
   "license": "LGPL-3.0",


### PR DESCRIPTION
I'm currently moving our billing extension directly into the sonarcloud core, and this default function is needed, but I clearly don't want to also depend on react-select inside sonar-web so I'm exposing it here. I know it's not ideal since it's kind of only for sonarcloud and it's billing part, but I still think it's better than also depending on react-select in the core just for that.

**Checklist**

* [ ] ~Write/update ITs~
* [x] Functional validation
* [ ] ~Documentation update~
* [x] Update changelog
