### PR TITLE
Update RadioToggle CSS

### DIFF
--- a/components/controls/RadioToggle.css
+++ b/components/controls/RadioToggle.css
@@ -52,6 +52,7 @@
   color: var(--darkBlue);
   height: calc(var(--controlHeight) - 2px);
   line-height: calc(var(--controlHeight) - 2px);
+  cursor: pointer;
 }
 
 .radio-toggle input[type='radio'] {


### PR DESCRIPTION
Use a pointer instead of the usual arrow to show that it is clickable.

![](https://media.giphy.com/media/OuxcU6pv31gC4/giphy.gif)