### PR TITLE
SONAR-12636 Add a disabled state to the toggle component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,13 @@
 
 ## Unreleased
 
+## 0.0.37
+
 - Bump to typescript@3.6.4
 - Fix BoxedTabs alignment
 - SONAR-12684 Fix glitched spinner in SearchBox
 - Don't fix BoxedTabs height
+- SONAR-12636 Add a disabled state to the toggle component
 
 ## 0.0.36
 

--- a/components/controls/Toggle.tsx
+++ b/components/controls/Toggle.tsx
@@ -24,6 +24,7 @@ import { Button } from './buttons';
 import './Toggle.css';
 
 interface Props {
+  disabled?: boolean;
   name?: string;
   onChange?: (value: boolean) => void;
   value: boolean | string;
@@ -43,11 +44,12 @@ export default class Toggle extends React.PureComponent<Props> {
   };
 
   render() {
+    const { disabled, name } = this.props;
     const value = this.getValue();
     const className = classNames('boolean-toggle', { 'boolean-toggle-on': value });
 
     return (
-      <Button className={className} name={this.props.name} onClick={this.handleClick}>
+      <Button className={className} disabled={disabled} name={name} onClick={this.handleClick}>
         <div className="boolean-toggle-handle">
           <CheckIcon size={12} />
         </div>

--- a/components/controls/__tests__/Toggle-test.tsx
+++ b/components/controls/__tests__/Toggle-test.tsx
@@ -17,23 +17,33 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-import { shallow } from 'enzyme';
+
+import { mount } from 'enzyme';
 import * as React from 'react';
 import { click } from '../../../helpers/testUtils';
 import Toggle from '../Toggle';
 
-it('should render', () => {
-  const Toggle = shallowRender();
-  expect(Toggle.is('Button')).toBe(true);
+it('should render correctly', () => {
+  const wrapper = mountRender();
+  expect(wrapper).toMatchSnapshot();
 });
 
-it('should call onChange', () => {
+it('should call onChange if NOT disabled', () => {
   const onChange = jest.fn();
-  const Toggle = shallowRender({ onChange });
-  click(Toggle);
+  const wrapper = mountRender({ disabled: false, onChange });
+  click(wrapper.find('button'));
   expect(onChange).toBeCalledWith(false);
 });
 
-function shallowRender(props?: Partial<Toggle['props']>) {
-  return shallow(<Toggle onChange={() => true} value={true} {...props} />);
+it('should NOT call onChange if disabled', () => {
+  const onChange = jest.fn();
+  const wrapper = mountRender({ disabled: true, onChange });
+  click(wrapper.find('button'));
+  expect(onChange).not.toHaveBeenCalled();
+});
+
+function mountRender(props?: Partial<Toggle['props']>) {
+  return mount(
+    <Toggle disabled={true} name="toggle-name" onChange={jest.fn()} value={true} {...props} />
+  );
 }

--- a/components/controls/__tests__/__snapshots__/Toggle-test.tsx.snap
+++ b/components/controls/__tests__/__snapshots__/Toggle-test.tsx.snap
@@ -1,0 +1,63 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render correctly 1`] = `
+<Toggle
+  disabled={true}
+  name="toggle-name"
+  onChange={[MockFunction]}
+  value={true}
+>
+  <Button
+    className="boolean-toggle boolean-toggle-on"
+    disabled={true}
+    name="toggle-name"
+    onClick={[Function]}
+  >
+    <button
+      className="button boolean-toggle boolean-toggle-on"
+      disabled={true}
+      name="toggle-name"
+      onClick={[Function]}
+      type="button"
+    >
+      <div
+        className="boolean-toggle-handle"
+      >
+        <CheckIcon
+          size={12}
+        >
+          <Icon
+            size={12}
+          >
+            <svg
+              height={12}
+              style={
+                Object {
+                  "clipRule": "evenodd",
+                  "fillRule": "evenodd",
+                  "strokeLinejoin": "round",
+                  "strokeMiterlimit": 1.41421,
+                }
+              }
+              version="1.1"
+              viewBox="0 0 16 16"
+              width={12}
+              xmlSpace="preserve"
+              xmlnsXlink="http://www.w3.org/1999/xlink"
+            >
+              <path
+                d="M14.92 4.804q0 0.357-0.25 0.607l-7.679 7.679q-0.25 0.25-0.607 0.25t-0.607-0.25l-4.446-4.446q-0.25-0.25-0.25-0.607t0.25-0.607l1.214-1.214q0.25-0.25 0.607-0.25t0.607 0.25l2.625 2.634 5.857-5.866q0.25-0.25 0.607-0.25t0.607 0.25l1.214 1.214q0.25 0.25 0.25 0.607z"
+                style={
+                  Object {
+                    "fill": "currentColor",
+                  }
+                }
+              />
+            </svg>
+          </Icon>
+        </CheckIcon>
+      </div>
+    </button>
+  </Button>
+</Toggle>
+`;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sonar-ui-common",
-  "version": "0.0.36",
+  "version": "0.0.37",
   "description": "Common UI lib for SonarQube and SonarCloud",
   "repository": "SonarSource/sonar-ui-common",
   "license": "LGPL-3.0",


### PR DESCRIPTION
Add a disabled state to the toggle component, in order to avoid multiple click when calling an api for example.

Sonar-enterprise associated [PR](https://github.com/SonarSource/sonar-enterprise/pull/2243).