### PR TITLE
Make BoxedTabs height adjustable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Bump to typescript@3.6.4
 - Fix BoxedTabs alignment
 - SONAR-12684 Fix glitched spinner in SearchBox
+- Don't fix BoxedTabs height
 
 ## 0.0.36
 

--- a/components/controls/BoxedTabs.tsx
+++ b/components/controls/BoxedTabs.tsx
@@ -42,10 +42,10 @@ const StyledTab = styled.button<{ active: boolean }>`
   border-bottom: none;
   margin-bottom: -1px;
   min-width: 128px;
-  height: 56px;
+  min-height: 56px;
   cursor: pointer;
   outline: 0;
-  padding: 0 calc(2 * ${props => props.theme.sizes.gridSize});
+  padding: calc(2 * ${props => props.theme.sizes.gridSize});
 
   &:hover {
     background-color: ${props => props.theme.colors.barBackgroundColorHighlight};

--- a/components/controls/__tests__/__snapshots__/BoxedTabs-test.tsx.snap
+++ b/components/controls/__tests__/__snapshots__/BoxedTabs-test.tsx.snap
@@ -20,10 +20,10 @@ exports[`should render correctly 1`] = `
   border-bottom: none;
   margin-bottom: -1px;
   min-width: 128px;
-  height: 56px;
+  min-height: 56px;
   cursor: pointer;
   outline: 0;
-  padding: 0 calc(2 * 8px);
+  padding: calc(2 * 8px);
 }
 
 .emotion-1:last-child {
@@ -49,10 +49,10 @@ exports[`should render correctly 1`] = `
   border-bottom: none;
   margin-bottom: -1px;
   min-width: 128px;
-  height: 56px;
+  min-height: 56px;
   cursor: pointer;
   outline: 0;
-  padding: 0 calc(2 * 8px);
+  padding: calc(2 * 8px);
 }
 
 .emotion-3:last-child {


### PR DESCRIPTION
See:

* https://jira.sonarsource.com/browse/SONAR-12632

Currently, the boxed tabs have a fixed height. But they should adapt based on their content.

**Checklist**

* [x] Functional validation
* [ ] ~Documentation update~
* [x] Update changelog
