### PR TITLE
Fix webapp infinite reload during BG deployement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - SC-1402 Fix lazyLoadComponent error handling
 - SC-1402 requestTryAndRepeatUntil now returns the error response after the max number of tries
+- SC-1402 Replace usage of lazyLoad by lazyLoadComponent in Select
 
 ## 0.0.39
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- SC-1402 Fix lazyLoadComponent error handling
+- SC-1402 requestTryAndRepeatUntil now returns the error response after the max number of tries
+
 ## 0.0.39
 
 - SC-1379 In requests, allow to bypass the checkstatus redirection to login page when getting a 401 error

--- a/components/controls/Select.tsx
+++ b/components/controls/Select.tsx
@@ -24,7 +24,7 @@ import {
   ReactCreatableSelectProps,
   ReactSelectProps
 } from 'react-select';
-import { lazyLoad } from '../lazyLoad';
+import { lazyLoadComponent } from '../lazyLoadComponent';
 import { ClearButton } from './buttons';
 import './Select.css';
 
@@ -33,9 +33,11 @@ declare module 'react-select' {
 }
 
 const ReactSelectLib = import('react-select');
-const ReactSelect = lazyLoad(() => ReactSelectLib);
-const ReactCreatable = lazyLoad(() => ReactSelectLib.then(lib => ({ default: lib.Creatable })));
-const ReactAsync = lazyLoad(() => ReactSelectLib.then(lib => ({ default: lib.Async })));
+const ReactSelect = lazyLoadComponent(() => ReactSelectLib);
+const ReactCreatable = lazyLoadComponent(() =>
+  ReactSelectLib.then(lib => ({ default: lib.Creatable }))
+);
+const ReactAsync = lazyLoadComponent(() => ReactSelectLib.then(lib => ({ default: lib.Async })));
 
 function renderInput() {
   return <ClearButton className="button-tiny spacer-left text-middle" iconProps={{ size: 12 }} />;

--- a/components/lazyLoadComponent.tsx
+++ b/components/lazyLoadComponent.tsx
@@ -22,16 +22,12 @@ import { translate } from '../helpers/l10n';
 import { requestTryAndRepeatUntil } from '../helpers/request';
 import { Alert } from './ui/Alert';
 
-interface ImportError {
-  request?: string;
-}
-
 export function lazyLoadComponent<T extends React.ComponentType<any>>(
   factory: () => Promise<{ default: T }>,
   displayName?: string
 ) {
   const LazyComponent = React.lazy(() =>
-    requestTryAndRepeatUntil(factory, { max: 1, slowThreshold: 2 }, () => true)
+    requestTryAndRepeatUntil(factory, { max: 2, slowThreshold: 2 }, () => true)
   );
 
   function LazyComponentWrapper(props: React.ComponentProps<T>) {
@@ -53,19 +49,19 @@ interface ErrorBoundaryProps {
 }
 
 interface ErrorBoundaryState {
-  error?: ImportError;
+  hasError: boolean;
 }
 
 export class LazyErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
-  state: ErrorBoundaryState = {};
+  state: ErrorBoundaryState = { hasError: false };
 
-  static getDerivedStateFromError(error: ImportError) {
+  static getDerivedStateFromError() {
     // Update state so the next render will show the fallback UI.
-    return { error };
+    return { hasError: true };
   }
 
   render() {
-    if (this.state.error && this.state.error.request) {
+    if (this.state.hasError) {
       return <Alert variant="error">{translate('default_error_message')}</Alert>;
     }
     return this.props.children;

--- a/helpers/request.ts
+++ b/helpers/request.ts
@@ -280,7 +280,8 @@ function tryRequestAgain<T>(
   repeatAPICall: () => Promise<T>,
   tries: { max: number; slowThreshold: number },
   stopRepeat: (response: T) => boolean,
-  repeatErrors: number[] = []
+  repeatErrors: number[] = [],
+  lastError?: Response
 ) {
   tries.max--;
   if (tries.max !== 0) {
@@ -291,7 +292,7 @@ function tryRequestAgain<T>(
       );
     });
   }
-  return Promise.reject();
+  return Promise.reject(lastError);
 }
 
 export function requestTryAndRepeatUntil<T>(
@@ -309,7 +310,7 @@ export function requestTryAndRepeatUntil<T>(
     },
     (error: Response) => {
       if (repeatErrors.length === 0 || repeatErrors.includes(error.status)) {
-        return tryRequestAgain(repeatAPICall, tries, stopRepeat, repeatErrors);
+        return tryRequestAgain(repeatAPICall, tries, stopRepeat, repeatErrors, error);
       }
       return Promise.reject(error);
     }


### PR DESCRIPTION
I dropped all usage of `lazyLoad` in SonarCloud to avoid infinite reload issues during Blue Green deployment. So I also dropped all it's usage in sonar-ui-common.

@wouter-admiraal-sonarsource @philippe-perrin-sonarsource @jeremy-davis-sonarsource : SQ should not be impacted by this but switching to `lazyLoadComponent` is advised, it prevent this bug from happening (which should not happen to you since you don't have BG deployement). And it better enforce props typings of the components. "Better"... I should say enforce at all, because `lazyLoad` doesn't, it uses any for the props.

**Checklist**

* [ ] ~Write/update ITs~
* [x] Functional validation
* [ ] ~Documentation update~
* [x] Update changelog
