### PR TITLE
SONAR-12679 Introduce new branch icon

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,10 +1,8 @@
-See:
-
-* ... links to JIRA tickets ...
+...description
 
 **Checklist**
 
-* [ ] Write/update ITs
 * [ ] Functional validation
 * [ ] Documentation update
 * [ ] Update changelog
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - SC-1402 Fix lazyLoadComponent error handling
 - SC-1402 requestTryAndRepeatUntil now returns the error response after the max number of tries
 - SC-1402 Replace usage of lazyLoad by lazyLoadComponent in Select
+- SONAR-12679 Introduce new BranchIcon
 
 ## 0.0.39
 

--- a/components/icons/BranchIcon.tsx
+++ b/components/icons/BranchIcon.tsx
@@ -1,0 +1,34 @@
+/*
+ * Sonar UI Common
+ * Copyright (C) 2019-2019 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+import * as React from 'react';
+import { IconProps, ThemedIcon } from './Icon';
+
+export default function BranchIcon({ className, fill, size }: IconProps) {
+  return (
+    <ThemedIcon className={className} size={size}>
+      {({ theme }) => (
+        <path
+          d="M12.5 6.5c0-1.1-.9-2-2-2s-2 .9-2 2c0 .8.5 1.5 1.2 1.8-.3.6-.7 1.1-1.2 1.4-.9.5-1.9.5-2.5.4V4c.9-.2 1.5-1 1.5-1.9 0-1.1-.9-2-2-2s-2 .9-2 2C3.5 3 4.1 3.8 5 4v8c-.9.2-1.5 1-1.5 1.9 0 1.1.9 2 2 2s2-.9 2-2c0-.9-.6-1.7-1.5-1.9v-1c.2 0 .5.1.7.1.7 0 1.5-.1 2.2-.6.8-.5 1.4-1.2 1.7-2.1 1.1 0 1.9-.9 1.9-1.9zm-8-4.4c0-.6.4-1 1-1s1 .4 1 1-.4 1-1 1-1-.5-1-1zm2 11.9c0 .6-.4 1-1 1s-1-.4-1-1 .4-1 1-1 1 .4 1 1zm4-6.5c-.6 0-1-.4-1-1s.4-1 1-1 1 .4 1 1-.4 1-1 1z"
+          style={{ fill: fill || theme.colors.blue }}
+        />
+      )}
+    </ThemedIcon>
+  );
+}


### PR DESCRIPTION
In SQ, we no longer use LLB or SLB icons. Instead, we use a single icon to represent any branch type. Note that this is basically a copy of the SLB icon. It's just for clarity. Probably SC will drop SLBs and LLBs soon too, so it will make sense to reference a `BranchIcon` instead of keeping `ShortLivingBranchIcon` around.

*Note:* this also removes the "Write IT" task in our PR template. It makes no sense in SUC 🤷‍♂ .

See:

* https://jira.sonarsource.com/browse/SONAR-12679

**Checklist**

* [x] Functional validation
* [ ] ~Documentation update~
* [x] Update changelog
