### PR TITLE
SONAR-12637 Allow ActionsDropdown to be positioned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- SONAR-12637 Allow ActionsDropdown to be positioned like any other dropdown
+
 ## 0.0.41
 
 - SONAR-12717 Add a helper to hide footer

--- a/components/controls/ActionsDropdown.tsx
+++ b/components/controls/ActionsDropdown.tsx
@@ -23,28 +23,32 @@ import * as React from 'react';
 import { Link } from 'react-router';
 import DropdownIcon from '../icons/DropdownIcon';
 import SettingsIcon from '../icons/SettingsIcon';
+import { PopupPlacement } from '../ui/popups';
 import { Button } from './buttons';
 import Dropdown from './Dropdown';
 
-interface Props {
+export interface ActionsDropdownProps {
   className?: string;
   children: React.ReactNode;
   onOpen?: () => void;
+  overlayPlacement?: PopupPlacement;
   small?: boolean;
   toggleClassName?: string;
 }
 
-export default function ActionsDropdown(props: Props) {
+export default function ActionsDropdown(props: ActionsDropdownProps) {
+  const { children, className, overlayPlacement, small, toggleClassName } = props;
   return (
     <Dropdown
-      className={props.className}
+      className={className}
       onOpen={props.onOpen}
-      overlay={<ul className="menu">{props.children}</ul>}>
+      overlay={<ul className="menu">{children}</ul>}
+      overlayPlacement={overlayPlacement}>
       <Button
-        className={classNames('dropdown-toggle', props.toggleClassName, {
-          'button-small': props.small
+        className={classNames('dropdown-toggle', toggleClassName, {
+          'button-small': small
         })}>
-        <SettingsIcon size={props.small ? 12 : 14} />
+        <SettingsIcon size={small ? 12 : 14} />
         <DropdownIcon className="little-spacer-left" />
       </Button>
     </Dropdown>

--- a/components/controls/__tests__/ActionsDropdown-test.tsx
+++ b/components/controls/__tests__/ActionsDropdown-test.tsx
@@ -1,0 +1,79 @@
+/*
+ * Sonar UI Common
+ * Copyright (C) 2019-2019 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+/* eslint-disable sonarjs/no-duplicate-string */
+import { shallow } from 'enzyme';
+import * as React from 'react';
+import { click } from '../../../helpers/testUtils';
+import { PopupPlacement } from '../../ui/popups';
+import ActionsDropdown, {
+  ActionsDropdownDivider,
+  ActionsDropdownItem,
+  ActionsDropdownProps
+} from '../ActionsDropdown';
+
+describe('ActionsDropdown', () => {
+  it('should render correctly', () => {
+    expect(shallowRender()).toMatchSnapshot();
+    expect(shallowRender({ small: false })).toMatchSnapshot();
+  });
+
+  function shallowRender(props: Partial<ActionsDropdownProps> = {}) {
+    return shallow(
+      <ActionsDropdown
+        className="foo"
+        onOpen={jest.fn()}
+        overlayPlacement={PopupPlacement.Bottom}
+        small={true}
+        toggleClassName="bar"
+        {...props}>
+        <span>Hello world</span>
+      </ActionsDropdown>
+    );
+  }
+});
+
+describe('ActionsDropdownItem', () => {
+  it('should render correctly', () => {
+    expect(shallowRender()).toMatchSnapshot();
+    expect(shallowRender({ destructive: true, id: 'baz', to: 'path/name' })).toMatchSnapshot();
+    expect(shallowRender({ download: 'foo/bar', to: 'path/name' })).toMatchSnapshot();
+  });
+
+  it('should trigger click', () => {
+    const onClick = jest.fn();
+    const wrapper = shallowRender({ onClick });
+    click(wrapper.find('a'));
+    expect(onClick).toBeCalled();
+  });
+
+  function shallowRender(props: Partial<ActionsDropdownItem['props']> = {}) {
+    return shallow(
+      <ActionsDropdownItem className="foo" onClick={jest.fn()} {...props}>
+        <span>Hello world</span>
+      </ActionsDropdownItem>
+    );
+  }
+});
+
+describe('ActionsDropdownDivider', () => {
+  it('should render correctly', () => {
+    expect(shallow(<ActionsDropdownDivider />)).toMatchSnapshot();
+  });
+});

--- a/components/controls/__tests__/__snapshots__/ActionsDropdown-test.tsx.snap
+++ b/components/controls/__tests__/__snapshots__/ActionsDropdown-test.tsx.snap
@@ -1,0 +1,107 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ActionsDropdown should render correctly 1`] = `
+<Dropdown
+  className="foo"
+  onOpen={[MockFunction]}
+  overlay={
+    <ul
+      className="menu"
+    >
+      <span>
+        Hello world
+      </span>
+    </ul>
+  }
+  overlayPlacement="bottom"
+>
+  <Button
+    className="dropdown-toggle bar button-small"
+  >
+    <SettingsIcon
+      size={12}
+    />
+    <DropdownIcon
+      className="little-spacer-left"
+    />
+  </Button>
+</Dropdown>
+`;
+
+exports[`ActionsDropdown should render correctly 2`] = `
+<Dropdown
+  className="foo"
+  onOpen={[MockFunction]}
+  overlay={
+    <ul
+      className="menu"
+    >
+      <span>
+        Hello world
+      </span>
+    </ul>
+  }
+  overlayPlacement="bottom"
+>
+  <Button
+    className="dropdown-toggle bar"
+  >
+    <SettingsIcon
+      size={14}
+    />
+    <DropdownIcon
+      className="little-spacer-left"
+    />
+  </Button>
+</Dropdown>
+`;
+
+exports[`ActionsDropdownDivider should render correctly 1`] = `
+<li
+  className="divider"
+/>
+`;
+
+exports[`ActionsDropdownItem should render correctly 1`] = `
+<li>
+  <a
+    className="foo"
+    href="#"
+    onClick={[Function]}
+  >
+    <span>
+      Hello world
+    </span>
+  </a>
+</li>
+`;
+
+exports[`ActionsDropdownItem should render correctly 2`] = `
+<li>
+  <Link
+    className="foo text-danger"
+    id="baz"
+    onlyActiveOnIndex={false}
+    style={Object {}}
+    to="path/name"
+  >
+    <span>
+      Hello world
+    </span>
+  </Link>
+</li>
+`;
+
+exports[`ActionsDropdownItem should render correctly 3`] = `
+<li>
+  <a
+    className="foo"
+    download="foo/bar"
+    href="path/name"
+  >
+    <span>
+      Hello world
+    </span>
+  </a>
+</li>
+`;


### PR DESCRIPTION
Allow the `ActionsDropdown` component to be positioned via the `overlayPlacement` prop, just as for the `Dropdown` component.

**Checklist**

* [x] Functional validation
* [ ] ~Documentation update~
* [x] Update changelog

