### PR TITLE
Prevent click event from bubbling when using ActionsDropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - BoxedTabs : add support for external css class
+- ConfirmModal: prevent click events from bubbling to the parent component
 
 ## 0.0.43
 

--- a/components/controls/ConfirmModal.tsx
+++ b/components/controls/ConfirmModal.tsx
@@ -21,6 +21,7 @@ import * as React from 'react';
 import { translate } from '../../helpers/l10n';
 import DeferredSpinner from '../ui/DeferredSpinner';
 import { ResetButtonLink, SubmitButton } from './buttons';
+import ClickEventBoundary from './ClickEventBoundary';
 import { ModalProps } from './Modal';
 import SimpleModal, { ChildrenProps } from './SimpleModal';
 
@@ -71,25 +72,27 @@ export default class ConfirmModal<T = string> extends React.PureComponent<Props<
       cancelButtonText = translate('cancel')
     } = this.props;
     return (
-      <form onSubmit={onFormSubmit}>
-        <header className="modal-head">
-          <h2>{header}</h2>
-          {headerDescription}
-        </header>
-        <div className="modal-body">{children}</div>
-        <footer className="modal-foot">
-          <DeferredSpinner className="spacer-right" loading={submitting} />
-          <SubmitButton
-            autoFocus={true}
-            className={isDestructive ? 'button-red' : undefined}
-            disabled={submitting || confirmDisable}>
-            {confirmButtonText}
-          </SubmitButton>
-          <ResetButtonLink disabled={submitting} onClick={onCloseClick}>
-            {cancelButtonText}
-          </ResetButtonLink>
-        </footer>
-      </form>
+      <ClickEventBoundary>
+        <form onSubmit={onFormSubmit}>
+          <header className="modal-head">
+            <h2>{header}</h2>
+            {headerDescription}
+          </header>
+          <div className="modal-body">{children}</div>
+          <footer className="modal-foot">
+            <DeferredSpinner className="spacer-right" loading={submitting} />
+            <SubmitButton
+              autoFocus={true}
+              className={isDestructive ? 'button-red' : undefined}
+              disabled={submitting || confirmDisable}>
+              {confirmButtonText}
+            </SubmitButton>
+            <ResetButtonLink disabled={submitting} onClick={onCloseClick}>
+              {cancelButtonText}
+            </ResetButtonLink>
+          </footer>
+        </form>
+      </ClickEventBoundary>
     );
   };
 

--- a/components/controls/__tests__/__snapshots__/ConfirmModal-test.tsx.snap
+++ b/components/controls/__tests__/__snapshots__/ConfirmModal-test.tsx.snap
@@ -39,43 +39,45 @@ exports[`should render correctly 2`] = `
   contentLabel="title"
   onRequestClose={[MockFunction]}
 >
-  <form
-    onSubmit={[Function]}
-  >
-    <header
-      className="modal-head"
+  <ClickEventBoundary>
+    <form
+      onSubmit={[Function]}
     >
-      <h2>
-        title
-      </h2>
-    </header>
-    <div
-      className="modal-body"
-    >
-      <p>
-        My confirm message
-      </p>
-    </div>
-    <footer
-      className="modal-foot"
-    >
-      <DeferredSpinner
-        className="spacer-right"
-        loading={false}
-        timeout={100}
-      />
-      <SubmitButton
-        autoFocus={true}
+      <header
+        className="modal-head"
       >
-        confirm
-      </SubmitButton>
-      <ResetButtonLink
-        disabled={false}
-        onClick={[Function]}
+        <h2>
+          title
+        </h2>
+      </header>
+      <div
+        className="modal-body"
       >
-        cancel
-      </ResetButtonLink>
-    </footer>
-  </form>
+        <p>
+          My confirm message
+        </p>
+      </div>
+      <footer
+        className="modal-foot"
+      >
+        <DeferredSpinner
+          className="spacer-right"
+          loading={false}
+          timeout={100}
+        />
+        <SubmitButton
+          autoFocus={true}
+        >
+          confirm
+        </SubmitButton>
+        <ResetButtonLink
+          disabled={false}
+          onClick={[Function]}
+        >
+          cancel
+        </ResetButtonLink>
+      </footer>
+    </form>
+  </ClickEventBoundary>
 </Modal>
 `;


### PR DESCRIPTION
A click inside a `ConfirmModal` on one of the buttons (submit or cancel) will bubble up to the parent component (thanks to React's event handling, because the modal is not even an actual child node in the DOM).

This is:

- not always desirable (on the Activity page, editing an event and saving/canceling triggers a click on the analysis... this is not the case if you simply hit Esc)
- probably never even useful

It should remain contained within the modal.

![click_bubbles_through_modal](https://user-images.githubusercontent.com/45544358/71519607-95c48800-28b8-11ea-9a6d-51f840ea5eca.gif)

**Checklist**

* [x] Functional validation
* [ ] ~Documentation update~
* [x] Update changelog

