### PR TITLE
Scroll chaining

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - SONAR-12860 Add boolean and numberic type for RadioToggle and fix size glitch.
 - SC-1258 Add 'copy to clipboard' feature to ActionsDropdownItem
 - SC-1258 Add new popup positioning TopLeft
+- SONAR-12452 Allow scrolling calls to be chained
 
 ## 0.0.48
 


### PR DESCRIPTION
With [SONAR-12452](https://jira.sonarsource.com/browse/SONAR-12452), we have an issue where several scrolls can be triggered at once. Browsers don't support this well, which breaks the flow in the UI.

This turns scroll requests into a queue, which gets immediately processed when called, but prevents multiple scrolls from overlapping. 

**Related PR:**

* https://github.com/SonarSource/sonar-enterprise/pull/2421

**Checklist**

* [x] Functional validation
* [ ] ~Documentation update~
* [x] Update changelog

