### PR TITLE
SC-1258 Add copy to clipboard feature to ActionsDropdownItem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 - SONAR-12860 Add boolean and numberic type for RadioToggle and fix size glitch.
+- SC-1258 Add 'copy to clipboard' feature to ActionsDropdownItem
+- SC-1258 Add new popup positioning TopLeft
 
 ## 0.0.48
 

--- a/components/controls/ActionsDropdown.tsx
+++ b/components/controls/ActionsDropdown.tsx
@@ -26,6 +26,9 @@ import SettingsIcon from '../icons/SettingsIcon';
 import { PopupPlacement } from '../ui/popups';
 import { Button } from './buttons';
 import Dropdown from './Dropdown';
+import { ClipboardBase } from './clipboard';
+import Tooltip from './Tooltip';
+import { translate } from '../../helpers/l10n';
 
 export interface ActionsDropdownProps {
   className?: string;
@@ -58,6 +61,8 @@ export default function ActionsDropdown(props: ActionsDropdownProps) {
 interface ItemProps {
   className?: string;
   children: React.ReactNode;
+  /** used to pass a string to copy to clipboard */
+  copyValue?: string;
   destructive?: boolean;
   /** used to pass a name of downloaded file */
   download?: string;
@@ -99,6 +104,22 @@ export class ActionsDropdownItem extends React.PureComponent<ItemProps> {
             {this.props.children}
           </Link>
         </li>
+      );
+    }
+
+    if (this.props.copyValue) {
+      return (
+        <ClipboardBase>
+          {({ setCopyButton, copySuccess }) => (
+            <Tooltip overlay={translate('copied_action')} visible={copySuccess}>
+              <li data-clipboard-text={this.props.copyValue} ref={setCopyButton}>
+                <a className={className} href="#" id={this.props.id} onClick={this.handleClick}>
+                  {this.props.children}
+                </a>
+              </li>
+            </Tooltip>
+          )}
+        </ClipboardBase>
       );
     }
 

--- a/components/controls/__tests__/ActionsDropdown-test.tsx
+++ b/components/controls/__tests__/ActionsDropdown-test.tsx
@@ -18,7 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 /* eslint-disable sonarjs/no-duplicate-string */
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import * as React from 'react';
 import { click } from '../../../helpers/testUtils';
 import { PopupPlacement } from '../../ui/popups';
@@ -63,9 +63,22 @@ describe('ActionsDropdownItem', () => {
     expect(onClick).toBeCalled();
   });
 
+  it('should render correctly copy item', () => {
+    const wrapper = mountRender({ copyValue: 'my content to copy to clipboard' });
+    expect(wrapper).toMatchSnapshot();
+  });
+
   function shallowRender(props: Partial<ActionsDropdownItem['props']> = {}) {
-    return shallow(
-      <ActionsDropdownItem className="foo" onClick={jest.fn()} {...props}>
+    return shallow(renderContent(props));
+  }
+
+  function mountRender(props: Partial<ActionsDropdownItem['props']> = {}) {
+    return mount(renderContent(props));
+  }
+
+  function renderContent(props: Partial<ActionsDropdownItem['props']> = {}) {
+    return (
+      <ActionsDropdownItem className="foo" {...props}>
         <span>Hello world</span>
       </ActionsDropdownItem>
     );

--- a/components/controls/__tests__/__snapshots__/ActionsDropdown-test.tsx.snap
+++ b/components/controls/__tests__/__snapshots__/ActionsDropdown-test.tsx.snap
@@ -105,3 +105,39 @@ exports[`ActionsDropdownItem should render correctly 3`] = `
   </a>
 </li>
 `;
+
+exports[`ActionsDropdownItem should render correctly copy item 1`] = `
+<ActionsDropdownItem
+  className="foo"
+  copyValue="my content to copy to clipboard"
+>
+  <ClipboardBase>
+    <Tooltip
+      overlay="copied_action"
+      visible={false}
+    >
+      <TooltipInner
+        mouseEnterDelay={0.1}
+        overlay="copied_action"
+        visible={false}
+      >
+        <li
+          data-clipboard-text="my content to copy to clipboard"
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+        >
+          <a
+            className="foo"
+            href="#"
+            onClick={[Function]}
+          >
+            <span>
+              Hello world
+            </span>
+          </a>
+        </li>
+      </TooltipInner>
+    </Tooltip>
+  </ClipboardBase>
+</ActionsDropdownItem>
+`;

--- a/components/ui/popups.css
+++ b/components/ui/popups.css
@@ -207,6 +207,30 @@
 }
 /* #endregion */
 
+/* #region .popup.is-top-left */
+.popup.is-top-left {
+  bottom: calc(100% + 8px);
+  left: 0;
+  margin: 0;
+  transform: translateX(-8px);
+}
+
+.popup.is-top-left .popup-arrow {
+  bottom: -6px;
+  top: auto;
+  left: 8px;
+  border-color: var(--barBorderColor) transparent transparent;
+  border-width: 6px 6px 0 6px;
+}
+
+.popup.is-top-left .popup-arrow:after {
+  left: -6px;
+  top: -7px;
+  border-width: 6px 6px 0 6px;
+  border-color: #fff transparent transparent;
+}
+/* #endregion */
+
 /* #region .popup & .menu or .multi-select */
 .popup:not(.no-padding) > .menu,
 .popup:not(.no-padding) > .multi-select {

--- a/components/ui/popups.tsx
+++ b/components/ui/popups.tsx
@@ -22,12 +22,22 @@ import * as React from 'react';
 import ClickEventBoundary from '../controls/ClickEventBoundary';
 import './popups.css';
 
+/**
+ * Positioning rules:
+ * - Bottom = below the block, horizontally centered
+ * - BottomLeft = below the block, horizontally left-aligned
+ * - BottomRight = below the block, horizontally right-aligned
+ * - LeftTop = on the left-side of the block, vertically top-aligned
+ * - RightTop = on the right-side of the block, vertically top-aligned
+ * - TopLeft = above the block, horizontally left-aligned
+ */
 export enum PopupPlacement {
   Bottom = 'bottom',
   BottomLeft = 'bottom-left',
   BottomRight = 'bottom-right',
   LeftTop = 'left-top',
-  RightTop = 'right-top'
+  RightTop = 'right-top',
+  TopLeft = 'top-left'
 }
 
 interface PopupProps {


### PR DESCRIPTION
New features:
- Copy to clipboard from an ActionsDropdownItem;
- Popup positioning TopLeft.

They will be used in SonarCloud within the LineOptionsPopup, which open on source viewers, to copy line permalink / line content.

Deployment is needed for https://github.com/SonarSource/sonarcloud-core/pull/497