### PR TITLE
Fix duplicate lodash in builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Switch to esnext modules in the tsconfig, to avoid duplicate lodash copies in sonar-web build
+
 ## 0.0.52
 
 - Introduce primary button styles

--- a/helpers/cookies.ts
+++ b/helpers/cookies.ts
@@ -17,19 +17,24 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-import { memoize } from 'lodash';
 
-const parseCookies = memoize(
-  (documentCookie: string): T.Dict<string> => {
-    const rawCookies = documentCookie.split('; ');
-    const cookies: T.Dict<string> = {};
-    rawCookies.forEach(candidate => {
-      const [key, value] = candidate.split('=');
-      cookies[key] = value;
-    });
-    return cookies;
+// Memoize only last parsed element
+const lastParsed: { cookie?: string; result?: T.Dict<string> } = {};
+
+function parseCookies(documentCookie: string): T.Dict<string> {
+  if (lastParsed.cookie === documentCookie && lastParsed.result) {
+    return lastParsed.result;
   }
-);
+  const rawCookies = documentCookie.split('; ');
+  const cookies: T.Dict<string> = {};
+  rawCookies.forEach(candidate => {
+    const [key, value] = candidate.split('=');
+    cookies[key] = value;
+  });
+  lastParsed.cookie = documentCookie;
+  lastParsed.result = cookies;
+  return cookies;
+}
 
 export function getCookie(name: string): string | undefined {
   return parseCookies(document.cookie)[name];

--- a/helpers/query.ts
+++ b/helpers/query.ts
@@ -17,8 +17,9 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-import { isEqual, isNil, omitBy } from 'lodash';
+import { isEqual } from 'lodash';
 import { isValidDate, parseDate, toNotSoISOString, toShortNotSoISOString } from './dates';
+import { omitNil } from './request';
 
 export function queriesEqual(a: T.RawQuery, b: T.RawQuery): boolean {
   const keysA = Object.keys(a);
@@ -32,7 +33,7 @@ export function queriesEqual(a: T.RawQuery, b: T.RawQuery): boolean {
 }
 
 export function cleanQuery(query: T.RawQuery): T.RawQuery {
-  return omitBy(query, isNil);
+  return omitNil(query);
 }
 
 export function parseAsBoolean(value: string | undefined, defaultValue = true): boolean {

--- a/helpers/request.ts
+++ b/helpers/request.ts
@@ -17,7 +17,6 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-import { isNil, omitBy } from 'lodash';
 import { stringify } from 'querystring';
 import { getCookie } from './cookies';
 import { translate } from './l10n';
@@ -50,8 +49,13 @@ export function getCSRFToken(): T.Dict<string> {
 
 export type RequestData = T.Dict<any>;
 
-export function omitNil(obj: RequestData): RequestData {
-  return omitBy(obj, isNil);
+export function omitNil<T>(obj: T.Dict<T>) {
+  return Object.keys(obj).reduce<T.Dict<T>>((newObj, key) => {
+    if (obj[key] != null) {
+      newObj[key] = obj[key];
+    }
+    return newObj;
+  }, {});
 }
 
 /**

--- a/helpers/urls.ts
+++ b/helpers/urls.ts
@@ -17,12 +17,10 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-import { isNil, omitBy } from 'lodash';
 import { stringify } from 'querystring';
+import { omitNil } from './request';
 
-interface Query {
-  [x: string]: string | undefined;
-}
+type Query = T.Dict<string | undefined>;
 
 export interface Location {
   pathname: string;
@@ -39,7 +37,7 @@ export function getHostUrl(): string {
 
 export function getPathUrlAsString(path: Location, internal = true): string {
   return `${internal ? getBaseUrl() : getHostUrl()}${path.pathname}?${stringify(
-    omitBy(path.query, isNil)
+    omitNil(path.query || {})
   )}`;
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "noUnusedParameters": true,
     "strict": true,
     "strictFunctionTypes": false,
-    "module": "commonjs",
+    "module": "esnext",
     "target": "es5",
     "lib": ["es2018", "dom"],
     "outDir": "build/dist",


### PR DESCRIPTION
This PR allows to remove lodash from being loaded in the initial chunks of sonar-web. And avoid having multiple copies of lodash duplicated in different chunks of the sonar-web build.

Related SC PR: https://github.com/SonarSource/sonarcloud-core/pull/539
Mainly the commit about [**Fix lodash duplication**](https://github.com/SonarSource/sonarcloud-core/pull/539/commits/67ddd94ec8a04d64237acd8f6192380ca6595385) is related to this change. The same should be applied to SQ build before updated to this version.

**Checklist**

* [ ] Functional validation
* [ ] Documentation update
* [x] Update changelog

