### PR TITLE
Introduce primary button style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Introduce primary button styles
+
 ## 0.0.51
 
 - SONAR-13049 Radio icons don't work well with flex

--- a/components/controls/buttons.css
+++ b/components/controls/buttons.css
@@ -52,6 +52,15 @@
   box-shadow: 0 0 0 3px rgba(35, 106, 151, 0.25);
 }
 
+.button-primary {
+  background: var(--darkBlue);
+  color: #fff;
+}
+
+.button-primary:hover {
+  background: var(--veryDarkBlue);
+}
+
 .button.disabled,
 .button:disabled,
 .button:disabled:hover,


### PR DESCRIPTION
In SonarQube, we're (finally!) introducing the concept of a "primary button", which should distinguish itself as a primary call to action, compared to other buttons.

**Checklist**

* [x] Functional validation
* [ ] ~Documentation update~
* [x] Update changelog

