### PR TITLE
Remove alert's tooltip in favor of an aria-label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Remove alert's tooltip in favor of an aria-label
+
 ## 0.0.54
 
 - SC-1814 Add Radio styles to RadioCard

--- a/components/ui/Alert.tsx
+++ b/components/ui/Alert.tsx
@@ -20,7 +20,6 @@
 import * as classNames from 'classnames';
 import * as React from 'react';
 import { translate } from '../../helpers/l10n';
-import Tooltip from '../controls/Tooltip';
 import AlertErrorIcon from '../icons/AlertErrorIcon';
 import AlertSuccessIcon from '../icons/AlertSuccessIcon';
 import AlertWarnIcon from '../icons/AlertWarnIcon';
@@ -147,11 +146,12 @@ export function Alert(props: AlertProps & React.HTMLAttributes<HTMLDivElement>) 
       variantInfo={variantInfo}
       {...domProps}>
       <StyledAlertInner isBanner={isBanner}>
-        <Tooltip overlay={translate('alert.tooltip', variant)}>
-          <StyledAlertIcon isBanner={isBanner} variantInfo={variantInfo}>
-            {variantInfo.icon}
-          </StyledAlertIcon>
-        </Tooltip>
+        <StyledAlertIcon
+          aria-label={translate('alert.tooltip', variant)}
+          isBanner={isBanner}
+          variantInfo={variantInfo}>
+          {variantInfo.icon}
+        </StyledAlertIcon>
         <StyledAlertContent className="alert-content">{props.children}</StyledAlertContent>
       </StyledAlertInner>
     </StyledAlert>

--- a/components/ui/__tests__/Alert-test.tsx
+++ b/components/ui/__tests__/Alert-test.tsx
@@ -21,6 +21,10 @@ import { shallow } from 'enzyme';
 import * as React from 'react';
 import { Alert, AlertProps } from '../Alert';
 
+it('should render properly', () => {
+  expect(shallowRender({ variant: 'error' })).toMatchSnapshot();
+});
+
 it('verification of all variants of alert', () => {
   const variants: AlertProps['variant'][] = ['error', 'warning', 'success', 'info', 'loading'];
   variants.forEach(variant => {

--- a/components/ui/__tests__/__snapshots__/Alert-test.tsx.snap
+++ b/components/ui/__tests__/__snapshots__/Alert-test.tsx.snap
@@ -77,6 +77,7 @@ exports[`should render banner alert with correct css 1`] = `
     class="emotion-2"
   >
     <div
+      aria-label="alert.tooltip.error"
       class="emotion-0"
     >
       <svg
@@ -101,6 +102,53 @@ exports[`should render banner alert with correct css 1`] = `
     </div>
   </div>
 </div>
+`;
+
+exports[`should render properly 1`] = `
+<Styled(div)
+  className="alert alert-test"
+  id="error-message"
+  isInline={false}
+  role="alert"
+  variantInfo={
+    Object {
+      "backGroundColor": "#f2dede",
+      "borderColor": "#f4b1b0",
+      "color": "#862422",
+      "icon": <AlertErrorIcon
+        fill="#a4030f"
+      />,
+    }
+  }
+>
+  <Styled(div)
+    isBanner={false}
+  >
+    <Styled(div)
+      aria-label="alert.tooltip.error"
+      isBanner={false}
+      variantInfo={
+        Object {
+          "backGroundColor": "#f2dede",
+          "borderColor": "#f4b1b0",
+          "color": "#862422",
+          "icon": <AlertErrorIcon
+            fill="#a4030f"
+          />,
+        }
+      }
+    >
+      <AlertErrorIcon
+        fill="#a4030f"
+      />
+    </Styled(div)>
+    <Styled(div)
+      className="alert-content"
+    >
+      This is an error!
+    </Styled(div)>
+  </Styled(div)>
+</Styled(div)>
 `;
 
 exports[`verification of all variants of alert 1`] = `


### PR DESCRIPTION
During the rewrite of the alert component, I've restored (it wasn't working) the tooltip that describes the type of the alert. It has been raised that it is kind of useless (and ugly ?), so I've dropped it in favor of an aria label to describe the alert to screen reader.