### PR TITLE
SONAR-12060 Fix modal header for long contents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fixing unmount issue with click outside handler component.
+- SONAR-12060 Fix titles in modal for long words
 
 ## 0.0.52
 

--- a/components/controls/Modal.css
+++ b/components/controls/Modal.css
@@ -99,6 +99,7 @@
   font-size: var(--bigFontSize);
   font-weight: bold;
   line-height: normal;
+  overflow-wrap: break-word;
 }
 
 .modal-body {


### PR DESCRIPTION
This allows to go from:

<img width="540" alt="Screenshot 2020-03-03 at 09 44 53" src="https://user-images.githubusercontent.com/49895321/75759884-92c19a00-5d36-11ea-9502-58122bd67688.png">

To:

<img width="540" alt="Screenshot 2020-03-03 at 09 44 36" src="https://user-images.githubusercontent.com/49895321/75759907-9a813e80-5d36-11ea-8211-3c53c37546b8.png">


**Checklist**

* [x] Functional validation
* [ ] Documentation update
* [x] Update changelog

