### PR TITLE
SC-1814 Add Radio styles to RadioCard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- SC-1814 Add Radio styles to RadioCard
+
 ## 0.0.53
 
 - Fixing unmount issue with click outside handler component.

--- a/components/controls/RadioCard.tsx
+++ b/components/controls/RadioCard.tsx
@@ -23,6 +23,7 @@ import { FormattedMessage } from 'react-intl';
 import { translate } from '../../helpers/l10n';
 import RecommendedIcon from '../icons/RecommendedIcon';
 import './RadioCard.css';
+import './Radio.css';
 
 export interface RadioCardProps {
   className?: string;
@@ -53,7 +54,7 @@ export default function RadioCard(props: Props) {
       role="radio"
       tabIndex={0}>
       <h2 className="radio-card-header big-spacer-bottom">
-        <span className="display-flex-center">
+        <span className="display-flex-center link-radio">
           {isActionable && (
             <i className={classNames('icon-radio', 'spacer-right', { 'is-checked': selected })} />
           )}

--- a/components/controls/__tests__/__snapshots__/RadioCard-test.tsx.snap
+++ b/components/controls/__tests__/__snapshots__/RadioCard-test.tsx.snap
@@ -11,7 +11,7 @@ exports[`should be actionable 1`] = `
     className="radio-card-header big-spacer-bottom"
   >
     <span
-      className="display-flex-center"
+      className="display-flex-center link-radio"
     >
       <i
         className="icon-radio spacer-right"
@@ -64,7 +64,7 @@ exports[`should be actionable 2`] = `
     className="radio-card-header big-spacer-bottom"
   >
     <span
-      className="display-flex-center"
+      className="display-flex-center link-radio"
     >
       <i
         className="icon-radio spacer-right is-checked"
@@ -93,7 +93,7 @@ exports[`should render correctly 1`] = `
     className="radio-card-header big-spacer-bottom"
   >
     <span
-      className="display-flex-center"
+      className="display-flex-center link-radio"
     >
       Radio Card
     </span>


### PR DESCRIPTION
We broke some styles in [this](https://github.com/SonarSource/sonarcloud-core/commit/d294556c700a292ac14a971845f925457259b2f6), let's fix that !

The RadioCard was missing some styles from the Radio.

**Checklist**

* [ ] Functional validation
* [ ] Documentation update
* [ ] Update changelog

