### PR TITLE
Add update-center's component used in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add update-center's component used in documentation
+
 ## 0.0.55
 
 - Remove alert's tooltip in favor of an aria-label

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Add update-center's component used in documentation
+- Update licence header
 
 ## 0.0.55
 

--- a/HEADER
+++ b/HEADER
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/__mocks__/mockedTheme.ts
+++ b/components/__mocks__/mockedTheme.ts
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/__tests__/lazyLoadComponent-test.tsx
+++ b/components/__tests__/lazyLoadComponent-test.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/charts/AdvancedTimeline.css
+++ b/components/charts/AdvancedTimeline.css
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/charts/AdvancedTimeline.tsx
+++ b/components/charts/AdvancedTimeline.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/charts/BarChart.css
+++ b/components/charts/BarChart.css
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/charts/BarChart.tsx
+++ b/components/charts/BarChart.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/charts/BubbleChart.css
+++ b/components/charts/BubbleChart.css
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/charts/BubbleChart.tsx
+++ b/components/charts/BubbleChart.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/charts/ColorGradientLegend.css
+++ b/components/charts/ColorGradientLegend.css
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/charts/ColorGradientLegend.tsx
+++ b/components/charts/ColorGradientLegend.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/charts/DonutChart.tsx
+++ b/components/charts/DonutChart.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/charts/Histogram.css
+++ b/components/charts/Histogram.css
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/charts/Histogram.tsx
+++ b/components/charts/Histogram.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/charts/LineChart.css
+++ b/components/charts/LineChart.css
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/charts/LineChart.tsx
+++ b/components/charts/LineChart.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/charts/TreeMap.css
+++ b/components/charts/TreeMap.css
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/charts/TreeMap.tsx
+++ b/components/charts/TreeMap.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/charts/TreeMapRect.tsx
+++ b/components/charts/TreeMapRect.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/charts/ZoomTimeLine.css
+++ b/components/charts/ZoomTimeLine.css
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/charts/ZoomTimeLine.tsx
+++ b/components/charts/ZoomTimeLine.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/charts/__tests__/AdvancedTimeline-test.tsx
+++ b/components/charts/__tests__/AdvancedTimeline-test.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/charts/__tests__/BarChart-test.tsx
+++ b/components/charts/__tests__/BarChart-test.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/charts/__tests__/BubbleChart-test.tsx
+++ b/components/charts/__tests__/BubbleChart-test.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/charts/__tests__/DonutChart-test.tsx
+++ b/components/charts/__tests__/DonutChart-test.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/charts/__tests__/Histogram-test.tsx
+++ b/components/charts/__tests__/Histogram-test.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/charts/__tests__/LineChart-test.tsx
+++ b/components/charts/__tests__/LineChart-test.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/charts/__tests__/TreeMap-test.tsx
+++ b/components/charts/__tests__/TreeMap-test.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/ActionsDropdown.tsx
+++ b/components/controls/ActionsDropdown.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/BackButton.tsx
+++ b/components/controls/BackButton.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/BoxedGroupAccordion.tsx
+++ b/components/controls/BoxedGroupAccordion.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/BoxedTabs.tsx
+++ b/components/controls/BoxedTabs.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/Checkbox.css
+++ b/components/controls/Checkbox.css
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/Checkbox.tsx
+++ b/components/controls/Checkbox.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/ClickEventBoundary.tsx
+++ b/components/controls/ClickEventBoundary.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/ConfirmButton.tsx
+++ b/components/controls/ConfirmButton.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/ConfirmModal.tsx
+++ b/components/controls/ConfirmModal.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/DocumentClickHandler.tsx
+++ b/components/controls/DocumentClickHandler.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/Dropdown.css
+++ b/components/controls/Dropdown.css
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/Dropdown.tsx
+++ b/components/controls/Dropdown.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/EscKeydownHandler.tsx
+++ b/components/controls/EscKeydownHandler.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/FavoriteButton.tsx
+++ b/components/controls/FavoriteButton.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/GlobalMessages.tsx
+++ b/components/controls/GlobalMessages.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/HelpTooltip.css
+++ b/components/controls/HelpTooltip.css
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/HelpTooltip.tsx
+++ b/components/controls/HelpTooltip.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/IdentityProviderLink.css
+++ b/components/controls/IdentityProviderLink.css
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/IdentityProviderLink.tsx
+++ b/components/controls/IdentityProviderLink.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/InputValidationField.tsx
+++ b/components/controls/InputValidationField.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/ListFooter.tsx
+++ b/components/controls/ListFooter.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/Modal.css
+++ b/components/controls/Modal.css
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/Modal.tsx
+++ b/components/controls/Modal.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/ModalButton.tsx
+++ b/components/controls/ModalButton.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/ModalValidationField.tsx
+++ b/components/controls/ModalValidationField.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/OutsideClickHandler.tsx
+++ b/components/controls/OutsideClickHandler.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/Radio.css
+++ b/components/controls/Radio.css
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/Radio.tsx
+++ b/components/controls/Radio.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/RadioCard.css
+++ b/components/controls/RadioCard.css
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/RadioCard.tsx
+++ b/components/controls/RadioCard.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or
@@ -22,8 +22,8 @@ import * as React from 'react';
 import { FormattedMessage } from 'react-intl';
 import { translate } from '../../helpers/l10n';
 import RecommendedIcon from '../icons/RecommendedIcon';
-import './RadioCard.css';
 import './Radio.css';
+import './RadioCard.css';
 
 export interface RadioCardProps {
   className?: string;

--- a/components/controls/RadioToggle.css
+++ b/components/controls/RadioToggle.css
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/RadioToggle.tsx
+++ b/components/controls/RadioToggle.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/ReloadButton.tsx
+++ b/components/controls/ReloadButton.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/ScreenPositionFixer.tsx
+++ b/components/controls/ScreenPositionFixer.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/SearchBox.css
+++ b/components/controls/SearchBox.css
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/SearchBox.tsx
+++ b/components/controls/SearchBox.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/SearchSelect.tsx
+++ b/components/controls/SearchSelect.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/Select.css
+++ b/components/controls/Select.css
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/Select.tsx
+++ b/components/controls/Select.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/SelectList.css
+++ b/components/controls/SelectList.css
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/SelectList.tsx
+++ b/components/controls/SelectList.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/SelectListListContainer.tsx
+++ b/components/controls/SelectListListContainer.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/SelectListListElement.tsx
+++ b/components/controls/SelectListListElement.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/SimpleModal.tsx
+++ b/components/controls/SimpleModal.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/Tabs.css
+++ b/components/controls/Tabs.css
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/Tabs.tsx
+++ b/components/controls/Tabs.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/Toggle.css
+++ b/components/controls/Toggle.css
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/Toggle.tsx
+++ b/components/controls/Toggle.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/Toggler.tsx
+++ b/components/controls/Toggler.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/Tooltip.css
+++ b/components/controls/Tooltip.css
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/Tooltip.tsx
+++ b/components/controls/Tooltip.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/ValidationForm.tsx
+++ b/components/controls/ValidationForm.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/ValidationInput.tsx
+++ b/components/controls/ValidationInput.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/ValidationModal.tsx
+++ b/components/controls/ValidationModal.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/__tests__/ActionsDropdown-test.tsx
+++ b/components/controls/__tests__/ActionsDropdown-test.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/__tests__/BoxedGroupAccordion-test.tsx
+++ b/components/controls/__tests__/BoxedGroupAccordion-test.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/__tests__/BoxedTabs-test.tsx
+++ b/components/controls/__tests__/BoxedTabs-test.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/__tests__/Checkbox-test.tsx
+++ b/components/controls/__tests__/Checkbox-test.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/__tests__/ClickEventBoundary-test.tsx
+++ b/components/controls/__tests__/ClickEventBoundary-test.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/__tests__/ConfirmButton-test.tsx
+++ b/components/controls/__tests__/ConfirmButton-test.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/__tests__/ConfirmModal-test.tsx
+++ b/components/controls/__tests__/ConfirmModal-test.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/__tests__/Dropdown-test.tsx
+++ b/components/controls/__tests__/Dropdown-test.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/__tests__/EscKeydownHandler-test.tsx
+++ b/components/controls/__tests__/EscKeydownHandler-test.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/__tests__/FavoriteButton-test.tsx
+++ b/components/controls/__tests__/FavoriteButton-test.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/__tests__/GlobalMessages-test.tsx
+++ b/components/controls/__tests__/GlobalMessages-test.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/__tests__/IdentityProviderLink-test.tsx
+++ b/components/controls/__tests__/IdentityProviderLink-test.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/__tests__/InputValidationField-test.tsx
+++ b/components/controls/__tests__/InputValidationField-test.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/__tests__/ListFooter-test.tsx
+++ b/components/controls/__tests__/ListFooter-test.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/__tests__/ModalButton-test.tsx
+++ b/components/controls/__tests__/ModalButton-test.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/__tests__/ModalValidationField-test.tsx
+++ b/components/controls/__tests__/ModalValidationField-test.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/__tests__/Radio-test.tsx
+++ b/components/controls/__tests__/Radio-test.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/__tests__/RadioCard-test.tsx
+++ b/components/controls/__tests__/RadioCard-test.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/__tests__/RadioToggle-test.tsx
+++ b/components/controls/__tests__/RadioToggle-test.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/__tests__/ScreenPositionFixer-test.tsx
+++ b/components/controls/__tests__/ScreenPositionFixer-test.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/__tests__/SearchBox-test.tsx
+++ b/components/controls/__tests__/SearchBox-test.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/__tests__/SearchSelect-test.tsx
+++ b/components/controls/__tests__/SearchSelect-test.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/__tests__/SelectList-test.tsx
+++ b/components/controls/__tests__/SelectList-test.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/__tests__/SelectListListContainer-test.tsx
+++ b/components/controls/__tests__/SelectListListContainer-test.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/__tests__/SelectListListElement-test.tsx
+++ b/components/controls/__tests__/SelectListListElement-test.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/__tests__/SimpleModal-test.tsx
+++ b/components/controls/__tests__/SimpleModal-test.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/__tests__/Tabs-test.tsx
+++ b/components/controls/__tests__/Tabs-test.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/__tests__/Toggle-test.tsx
+++ b/components/controls/__tests__/Toggle-test.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/__tests__/Toggler-test.tsx
+++ b/components/controls/__tests__/Toggler-test.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/__tests__/Tooltip-test.tsx
+++ b/components/controls/__tests__/Tooltip-test.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/__tests__/ValidationForm-test.tsx
+++ b/components/controls/__tests__/ValidationForm-test.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/__tests__/ValidationInput-test.tsx
+++ b/components/controls/__tests__/ValidationInput-test.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/__tests__/ValidationModal-test.tsx
+++ b/components/controls/__tests__/ValidationModal-test.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/__tests__/buttons-test.tsx
+++ b/components/controls/__tests__/buttons-test.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/__tests__/clipboard-test.tsx
+++ b/components/controls/__tests__/clipboard-test.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/buttons.css
+++ b/components/controls/buttons.css
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/buttons.tsx
+++ b/components/controls/buttons.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/controls/clipboard.tsx
+++ b/components/controls/clipboard.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/AlertErrorIcon.tsx
+++ b/components/icons/AlertErrorIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/AlertSuccessIcon.tsx
+++ b/components/icons/AlertSuccessIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/AlertWarnIcon.tsx
+++ b/components/icons/AlertWarnIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/BackIcon.tsx
+++ b/components/icons/BackIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/BranchIcon.tsx
+++ b/components/icons/BranchIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/BubblesIcon.tsx
+++ b/components/icons/BubblesIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/BugIcon.tsx
+++ b/components/icons/BugIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/BugTrackerIcon.tsx
+++ b/components/icons/BugTrackerIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/BulletListIcon.tsx
+++ b/components/icons/BulletListIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/CalendarIcon.tsx
+++ b/components/icons/CalendarIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/ChartLegendIcon.tsx
+++ b/components/icons/ChartLegendIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/CheckIcon.tsx
+++ b/components/icons/CheckIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/ChevronDownIcon.tsx
+++ b/components/icons/ChevronDownIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/ChevronLeftIcon.tsx
+++ b/components/icons/ChevronLeftIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/ChevronRightIcon.tsx
+++ b/components/icons/ChevronRightIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/ChevronUpIcon.tsx
+++ b/components/icons/ChevronUpIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/ClearIcon.tsx
+++ b/components/icons/ClearIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/ClockIcon.tsx
+++ b/components/icons/ClockIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/CodeSmellIcon.tsx
+++ b/components/icons/CodeSmellIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/CollapseIcon.tsx
+++ b/components/icons/CollapseIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/ContinuousIntegrationIcon.tsx
+++ b/components/icons/ContinuousIntegrationIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/CopyIcon.tsx
+++ b/components/icons/CopyIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/DeleteIcon.tsx
+++ b/components/icons/DeleteIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/DetachIcon.tsx
+++ b/components/icons/DetachIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/DropdownIcon.tsx
+++ b/components/icons/DropdownIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/EditIcon.tsx
+++ b/components/icons/EditIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/EllipsisIcon.tsx
+++ b/components/icons/EllipsisIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/ExpandIcon.tsx
+++ b/components/icons/ExpandIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/ExpandSnippetIcon.tsx
+++ b/components/icons/ExpandSnippetIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/FavoriteIcon.tsx
+++ b/components/icons/FavoriteIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/FilterIcon.tsx
+++ b/components/icons/FilterIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/GroupIcon.tsx
+++ b/components/icons/GroupIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/HelpIcon.tsx
+++ b/components/icons/HelpIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/HistoryIcon.tsx
+++ b/components/icons/HistoryIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/HomeIcon.tsx
+++ b/components/icons/HomeIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/HouseIcon.tsx
+++ b/components/icons/HouseIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/Icon.tsx
+++ b/components/icons/Icon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/InfoIcon.tsx
+++ b/components/icons/InfoIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/IssueIcon.tsx
+++ b/components/icons/IssueIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/IssueTypeIcon.tsx
+++ b/components/icons/IssueTypeIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/LightBulbIcon.tsx
+++ b/components/icons/LightBulbIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/LinkIcon.tsx
+++ b/components/icons/LinkIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/ListIcon.tsx
+++ b/components/icons/ListIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/LockIcon.tsx
+++ b/components/icons/LockIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/LongLivingBranchIcon.tsx
+++ b/components/icons/LongLivingBranchIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/MeasuresIcon.tsx
+++ b/components/icons/MeasuresIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/MinimizeIcon.tsx
+++ b/components/icons/MinimizeIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/NotificationIcon.tsx
+++ b/components/icons/NotificationIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/OnboardingAddMembersIcon.tsx
+++ b/components/icons/OnboardingAddMembersIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/OnboardingProjectIcon.tsx
+++ b/components/icons/OnboardingProjectIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/OnboardingTeamIcon.tsx
+++ b/components/icons/OnboardingTeamIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/OpenCloseIcon.tsx
+++ b/components/icons/OpenCloseIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/PendingIcon.tsx
+++ b/components/icons/PendingIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/PinIcon.tsx
+++ b/components/icons/PinIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/PlusCircleIcon.tsx
+++ b/components/icons/PlusCircleIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/PlusIcon.tsx
+++ b/components/icons/PlusIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/ProjectEventIcon.tsx
+++ b/components/icons/ProjectEventIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/ProjectLinkIcon.tsx
+++ b/components/icons/ProjectLinkIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/PullRequestIcon.tsx
+++ b/components/icons/PullRequestIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/QualifierIcon.tsx
+++ b/components/icons/QualifierIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/RecommendedIcon.tsx
+++ b/components/icons/RecommendedIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/RuleScopeIcon.tsx
+++ b/components/icons/RuleScopeIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/SCMIcon.tsx
+++ b/components/icons/SCMIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/SearchIcon.tsx
+++ b/components/icons/SearchIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/SecurityHotspotIcon.tsx
+++ b/components/icons/SecurityHotspotIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/SettingsIcon.tsx
+++ b/components/icons/SettingsIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/SeverityIcon.tsx
+++ b/components/icons/SeverityIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/ShortLivingBranchIcon.tsx
+++ b/components/icons/ShortLivingBranchIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/SortAscIcon.tsx
+++ b/components/icons/SortAscIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/SortDescIcon.tsx
+++ b/components/icons/SortDescIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/StatusIcon.tsx
+++ b/components/icons/StatusIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/TagsIcon.tsx
+++ b/components/icons/TagsIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/TestStatusIcon.tsx
+++ b/components/icons/TestStatusIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/TreeIcon.tsx
+++ b/components/icons/TreeIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/TreemapIcon.tsx
+++ b/components/icons/TreemapIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/VisibleIcon.tsx
+++ b/components/icons/VisibleIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/VulnerabilityIcon.tsx
+++ b/components/icons/VulnerabilityIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/WarningIcon.tsx
+++ b/components/icons/WarningIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/__tests__/Icon-test.tsx
+++ b/components/icons/__tests__/Icon-test.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/__tests__/IssueIcon-test.tsx
+++ b/components/icons/__tests__/IssueIcon-test.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/__tests__/IssueTypeIcon-test.tsx
+++ b/components/icons/__tests__/IssueTypeIcon-test.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/icons/__tests__/TestStatusIcon-test.tsx
+++ b/components/icons/__tests__/TestStatusIcon-test.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/lazyLoad.tsx
+++ b/components/lazyLoad.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/lazyLoadComponent.tsx
+++ b/components/lazyLoadComponent.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/theme.ts
+++ b/components/theme.ts
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/ui/Alert.tsx
+++ b/components/ui/Alert.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/ui/ContextNavBar.css
+++ b/components/ui/ContextNavBar.css
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/ui/ContextNavBar.tsx
+++ b/components/ui/ContextNavBar.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/ui/DeferredSpinner.css
+++ b/components/ui/DeferredSpinner.css
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/ui/DeferredSpinner.tsx
+++ b/components/ui/DeferredSpinner.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/ui/DuplicationsRating.css
+++ b/components/ui/DuplicationsRating.css
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/ui/DuplicationsRating.tsx
+++ b/components/ui/DuplicationsRating.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/ui/FilesCounter.tsx
+++ b/components/ui/FilesCounter.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/ui/GenericAvatar.tsx
+++ b/components/ui/GenericAvatar.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/ui/Level.css
+++ b/components/ui/Level.css
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/ui/Level.tsx
+++ b/components/ui/Level.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/ui/NavBar.css
+++ b/components/ui/NavBar.css
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/ui/NavBar.tsx
+++ b/components/ui/NavBar.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/ui/NavBarTabs.css
+++ b/components/ui/NavBarTabs.css
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/ui/NavBarTabs.tsx
+++ b/components/ui/NavBarTabs.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/ui/NewsBox.css
+++ b/components/ui/NewsBox.css
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/ui/NewsBox.tsx
+++ b/components/ui/NewsBox.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/ui/PageActions.tsx
+++ b/components/ui/PageActions.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/ui/Rating.css
+++ b/components/ui/Rating.css
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/ui/Rating.tsx
+++ b/components/ui/Rating.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/ui/SizeRating.css
+++ b/components/ui/SizeRating.css
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/ui/SizeRating.tsx
+++ b/components/ui/SizeRating.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/ui/__tests__/Alert-test.tsx
+++ b/components/ui/__tests__/Alert-test.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/ui/__tests__/DeferredSpinner-test.tsx
+++ b/components/ui/__tests__/DeferredSpinner-test.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/ui/__tests__/FilesCounter-test.tsx
+++ b/components/ui/__tests__/FilesCounter-test.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/ui/__tests__/Level-test.tsx
+++ b/components/ui/__tests__/Level-test.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/ui/__tests__/NewsBox-test.tsx
+++ b/components/ui/__tests__/NewsBox-test.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/ui/__tests__/PageActions-test.tsx
+++ b/components/ui/__tests__/PageActions-test.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/ui/__tests__/Rating-test.tsx
+++ b/components/ui/__tests__/Rating-test.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/ui/__tests__/SizeRating-test.tsx
+++ b/components/ui/__tests__/SizeRating-test.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/ui/__tests__/popups-test.tsx
+++ b/components/ui/__tests__/popups-test.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/ui/popups.css
+++ b/components/ui/popups.css
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/ui/popups.tsx
+++ b/components/ui/popups.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/ui/update-center/MetaData.css
+++ b/components/ui/update-center/MetaData.css
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/ui/update-center/MetaData.css
+++ b/components/ui/update-center/MetaData.css
@@ -1,0 +1,102 @@
+/*
+ * Sonar UI Common
+ * Copyright (C) 2019-2019 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+.update-center-meta-data {
+  margin: 16px 0;
+  padding: 16px 16px 8px 16px;
+  background: #f9f9fb;
+  border: 1px solid #e6e6e6;
+  border-radius: 3px;
+}
+
+.update-center-meta-data a svg {
+  margin-right: 8px;
+}
+
+.update-center-meta-data-header {
+  border-bottom: 1px solid #cfd3d7;
+  padding-bottom: 16px;
+}
+
+.update-center-meta-data-header,
+.update-center-meta-data-version-release-info,
+.update-center-meta-data-version-links {
+  display: flex;
+}
+
+.update-center-meta-data-header > * + *,
+.update-center-meta-data-version-release-info > * + * {
+  margin-left: 16px;
+}
+
+.update-center-meta-data-header > * + * {
+  padding-left: 16px;
+  border-left: 1px solid #cfd3d7;
+}
+
+.update-center-meta-data-versions {
+  margin-top: 16px;
+}
+
+.update-center-meta-data-versions-show-more {
+  font-size: 14px;
+  float: right;
+  color: #51575a;
+  border-color: #7b8184;
+  border-width: 0 0 1px 0;
+  padding-left: 0;
+  padding-right: 0;
+  background: transparent;
+  cursor: pointer;
+}
+
+.update-center-meta-data-versions-show-more:hover {
+  color: #2d3032;
+  border-color: #2d3032;
+}
+
+.update-center-meta-data-version {
+  margin-bottom: 16px;
+}
+
+.update-center-meta-data-version + .update-center-meta-data-version {
+  padding-top: 8px;
+  border-top: 1px dashed #cfd3d7;
+}
+
+.update-center-meta-data-version-version {
+  font-weight: bold;
+  font-size: 18px;
+}
+
+.update-center-meta-data-version-release-info {
+  margin-top: 8px;
+  font-style: italic;
+}
+
+.update-center-meta-data-version-release-description {
+  margin-top: 8px;
+}
+
+.update-center-meta-data-version-download > a,
+.update-center-meta-data-version-release-notes > a {
+  display: inline-block;
+  margin: 8px 16px 0 0;
+}

--- a/components/ui/update-center/MetaData.tsx
+++ b/components/ui/update-center/MetaData.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/ui/update-center/MetaData.tsx
+++ b/components/ui/update-center/MetaData.tsx
@@ -1,0 +1,112 @@
+/*
+ * Sonar UI Common
+ * Copyright (C) 2019-2019 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import * as React from 'react';
+import { getJSON } from '../../../helpers/request';
+import './MetaData.css';
+import MetaDataVersions from './MetaDataVersions';
+import { MetaDataInformation } from './update-center-metadata';
+
+interface Props {
+  updateCenterKey?: string;
+}
+
+interface State {
+  data?: MetaDataInformation;
+}
+
+export default class MetaData extends React.Component<Props, State> {
+  mounted = false;
+  state: State = {};
+
+  componentDidMount() {
+    this.mounted = true;
+    this.fetchData();
+  }
+
+  componentDidUpdate(prevProps: Props) {
+    if (prevProps.updateCenterKey !== this.props.updateCenterKey) {
+      this.fetchData();
+    }
+  }
+
+  componentWillUnmount() {
+    this.mounted = false;
+  }
+
+  fetchData() {
+    const { updateCenterKey } = this.props;
+
+    if (updateCenterKey) {
+      getJSON(`https://update.sonarsource.org/${updateCenterKey}.json`).then(
+        (data: MetaDataInformation) => {
+          if (this.mounted) {
+            this.setState({ data });
+          }
+        },
+        () => this.setState({ data: undefined })
+      );
+    } else {
+      this.setState({ data: undefined });
+    }
+  }
+
+  render() {
+    const { data } = this.state;
+
+    if (!data) {
+      return null;
+    }
+
+    const { isSonarSourceCommercial, issueTrackerURL, license, organization, versions } = data;
+
+    let vendor;
+    if (organization) {
+      vendor = organization.name;
+      if (organization.url) {
+        vendor = (
+          <a href={organization.url} rel="noopener noreferrer" target="_blank">
+            {vendor}
+          </a>
+        );
+      }
+    }
+
+    return (
+      <div className="update-center-meta-data">
+        <div className="update-center-meta-data-header">
+          {vendor && <span className="update-center-meta-data-vendor">By {vendor}</span>}
+          {license && <span className="update-center-meta-data-license">{license}</span>}
+          {issueTrackerURL && (
+            <span className="update-center-meta-data-issue-tracker">
+              <a href={issueTrackerURL} rel="noopener noreferrer" target="_blank">
+                Issue Tracker
+              </a>
+            </span>
+          )}
+          {isSonarSourceCommercial && (
+            <span className="update-center-meta-data-supported">Supported by SonarSource</span>
+          )}
+        </div>
+        {versions && versions.length > 0 && <MetaDataVersions versions={versions} />}
+      </div>
+    );
+  }
+}

--- a/components/ui/update-center/MetaDataVersion.tsx
+++ b/components/ui/update-center/MetaDataVersion.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/ui/update-center/MetaDataVersion.tsx
+++ b/components/ui/update-center/MetaDataVersion.tsx
@@ -1,0 +1,99 @@
+/*
+ * Sonar UI Common
+ * Copyright (C) 2019-2019 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import classNames from 'classnames';
+import * as React from 'react';
+import { AdvancedDownloadUrl, MetaDataVersionInformation } from './update-center-metadata';
+
+export interface MetaDataVersionProps {
+  versionInformation: MetaDataVersionInformation;
+}
+
+export default function MetaDataVersion(props: MetaDataVersionProps) {
+  const {
+    versionInformation: {
+      archived,
+      changeLogUrl,
+      compatibility,
+      date,
+      description,
+      downloadURL,
+      version
+    }
+  } = props;
+
+  const fallbackLabel = 'Download';
+
+  const advancedDownloadUrls = isAdvancedDownloadUrlArray(downloadURL)
+    ? downloadURL.map(url => ({ ...url, label: url.label || fallbackLabel }))
+    : [{ label: fallbackLabel, url: downloadURL }];
+
+  return (
+    <div
+      className={classNames('update-center-meta-data-version', {
+        'update-center-meta-data-version-archived': archived
+      })}>
+      <div className="update-center-meta-data-version-version">{version}</div>
+
+      <div className="update-center-meta-data-version-release-info">
+        {date && <time className="update-center-meta-data-version-release-date">{date}</time>}
+
+        {compatibility && (
+          <span className="update-center-meta-data-version-compatibility">{compatibility}</span>
+        )}
+      </div>
+
+      {description && (
+        <div className="update-center-meta-data-version-release-description">{description}</div>
+      )}
+
+      {(advancedDownloadUrls.length > 0 || changeLogUrl) && (
+        <div className="update-center-meta-data-version-release-links">
+          {advancedDownloadUrls.length > 0 &&
+            advancedDownloadUrls.map(
+              (advancedDownloadUrl, i) =>
+                advancedDownloadUrl.url && (
+                  // eslint-disable-next-line react/no-array-index-key
+                  <span className="update-center-meta-data-version-download" key={i}>
+                    <a href={advancedDownloadUrl.url} rel="noopener noreferrer" target="_blank">
+                      {advancedDownloadUrl.label}
+                    </a>
+                  </span>
+                )
+            )}
+
+          {changeLogUrl && (
+            <span className="update-center-meta-data-version-release-notes">
+              <a href={changeLogUrl} rel="noopener noreferrer" target="_blank">
+                Release notes
+              </a>
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function isAdvancedDownloadUrlArray(
+  downloadUrl: string | AdvancedDownloadUrl[] | undefined
+): downloadUrl is AdvancedDownloadUrl[] {
+  return !!downloadUrl && typeof downloadUrl !== 'string';
+}

--- a/components/ui/update-center/MetaDataVersions.tsx
+++ b/components/ui/update-center/MetaDataVersions.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/ui/update-center/MetaDataVersions.tsx
+++ b/components/ui/update-center/MetaDataVersions.tsx
@@ -1,0 +1,85 @@
+/*
+ * Sonar UI Common
+ * Copyright (C) 2019-2019 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import * as React from 'react';
+import MetaDataVersion from './MetaDataVersion';
+import { MetaDataVersionInformation } from './update-center-metadata';
+
+interface Props {
+  versions: MetaDataVersionInformation[];
+}
+
+interface State {
+  collapsed: boolean;
+}
+
+export default class MetaDataVersions extends React.Component<Props, State> {
+  state: State = {
+    collapsed: true
+  };
+
+  componentDidUpdate(prevProps: Props) {
+    if (prevProps.versions !== this.props.versions) {
+      this.setState({ collapsed: true });
+    }
+  }
+
+  handleClick = (event: React.SyntheticEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    event.currentTarget.blur();
+    this.setState(({ collapsed }) => ({ collapsed: !collapsed }));
+  };
+
+  render() {
+    const { versions } = this.props;
+    const { collapsed } = this.state;
+
+    const archivedVersions = versions.filter(version => version.archived);
+    const currentVersions = versions.filter(version => !version.archived);
+
+    return (
+      <div className="update-center-meta-data-versions">
+        {archivedVersions.length > 0 && (
+          <button
+            className="update-center-meta-data-versions-show-more"
+            onClick={this.handleClick}
+            type="button">
+            {collapsed ? 'Show more versions' : 'Show fewer versions'}
+          </button>
+        )}
+
+        {currentVersions.map(versionInformation => (
+          <MetaDataVersion
+            key={versionInformation.version}
+            versionInformation={versionInformation}
+          />
+        ))}
+
+        {!collapsed &&
+          archivedVersions.map(archivedVersionInformation => (
+            <MetaDataVersion
+              key={archivedVersionInformation.version}
+              versionInformation={archivedVersionInformation}
+            />
+          ))}
+      </div>
+    );
+  }
+}

--- a/components/ui/update-center/__tests__/MetaData-test.tsx
+++ b/components/ui/update-center/__tests__/MetaData-test.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/ui/update-center/__tests__/MetaData-test.tsx
+++ b/components/ui/update-center/__tests__/MetaData-test.tsx
@@ -1,0 +1,54 @@
+/*
+ * Sonar UI Common
+ * Copyright (C) 2019-2019 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { shallow } from 'enzyme';
+import * as React from 'react';
+import { getJSON } from '../../../../helpers/request';
+import { waitAndUpdate } from '../../../../helpers/testUtils';
+import MetaData from '../MetaData';
+import { mockMetaDataInformation } from '../mocks/update-center-metadata';
+
+jest.mock('../../../../helpers/request', () => ({
+  getJSON: jest.fn()
+}));
+
+it('should render correctly', async () => {
+  const metaDataInfo = mockMetaDataInformation();
+  (getJSON as jest.Mock).mockResolvedValueOnce(metaDataInfo);
+
+  const wrapper = shallowRender();
+  await waitAndUpdate(wrapper);
+  expect(wrapper).toMatchSnapshot();
+});
+
+it('should render correctly with organization', async () => {
+  const metaDataInfo = mockMetaDataInformation({
+    organization: { name: 'test-org', url: 'test-org-url' }
+  });
+  (getJSON as jest.Mock).mockResolvedValueOnce(metaDataInfo);
+
+  const wrapper = shallowRender();
+  await waitAndUpdate(wrapper);
+  expect(wrapper).toMatchSnapshot();
+});
+
+function shallowRender(props?: Partial<MetaData['props']>) {
+  return shallow<MetaData>(<MetaData updateCenterKey="apex" {...props} />);
+}

--- a/components/ui/update-center/__tests__/MetaDataVersion-test.tsx
+++ b/components/ui/update-center/__tests__/MetaDataVersion-test.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/ui/update-center/__tests__/MetaDataVersion-test.tsx
+++ b/components/ui/update-center/__tests__/MetaDataVersion-test.tsx
@@ -1,0 +1,46 @@
+/*
+ * Sonar UI Common
+ * Copyright (C) 2019-2019 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { shallow } from 'enzyme';
+import * as React from 'react';
+import MetaDataVersion, { MetaDataVersionProps } from '../MetaDataVersion';
+import { mockMetaDataVersionInformation } from '../mocks/update-center-metadata';
+
+it('should render correctly', () => {
+  expect(shallowRender()).toMatchSnapshot();
+  expect(
+    shallowRender({
+      versionInformation: mockMetaDataVersionInformation({
+        downloadURL: [{ label: 'macos 64 bits', url: '' }]
+      })
+    })
+  ).toMatchSnapshot('with advanced downloadUrl');
+  expect(
+    shallowRender({
+      versionInformation: { version: '2.0' }
+    })
+  ).toMatchSnapshot('with very few info');
+});
+
+function shallowRender(props?: Partial<MetaDataVersionProps>) {
+  return shallow(
+    <MetaDataVersion versionInformation={mockMetaDataVersionInformation()} {...props} />
+  );
+}

--- a/components/ui/update-center/__tests__/MetaDataVersions-test.tsx
+++ b/components/ui/update-center/__tests__/MetaDataVersions-test.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/ui/update-center/__tests__/MetaDataVersions-test.tsx
+++ b/components/ui/update-center/__tests__/MetaDataVersions-test.tsx
@@ -1,0 +1,52 @@
+/*
+ * Sonar UI Common
+ * Copyright (C) 2019-2019 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { shallow } from 'enzyme';
+import * as React from 'react';
+import { click } from '../../../../helpers/testUtils';
+import MetaDataVersion from '../MetaDataVersion';
+import MetaDataVersions from '../MetaDataVersions';
+import { mockMetaDataVersionInformation } from '../mocks/update-center-metadata';
+
+it('should render correctly', () => {
+  const wrapper = shallowRender();
+  expect(wrapper).toMatchSnapshot();
+});
+
+it('should properly handle show more / show less', () => {
+  const wrapper = shallowRender();
+  expect(wrapper.find(MetaDataVersion).length).toBe(1);
+
+  click(wrapper.find('.update-center-meta-data-versions-show-more'));
+  expect(wrapper.find(MetaDataVersion).length).toBe(3);
+});
+
+function shallowRender(props?: Partial<MetaDataVersions['props']>) {
+  return shallow<MetaDataVersions>(
+    <MetaDataVersions
+      versions={[
+        mockMetaDataVersionInformation({ version: '3.0' }),
+        mockMetaDataVersionInformation({ version: '2.0', archived: true }),
+        mockMetaDataVersionInformation({ version: '1.0', archived: true })
+      ]}
+      {...props}
+    />
+  );
+}

--- a/components/ui/update-center/__tests__/__snapshots__/MetaData-test.tsx.snap
+++ b/components/ui/update-center/__tests__/__snapshots__/MetaData-test.tsx.snap
@@ -1,0 +1,133 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render correctly 1`] = `
+<div
+  className="update-center-meta-data"
+>
+  <div
+    className="update-center-meta-data-header"
+  >
+    <span
+      className="update-center-meta-data-vendor"
+    >
+      By 
+      <a
+        href="http://www.sonarsource.com/"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        SonarSource
+      </a>
+    </span>
+    <span
+      className="update-center-meta-data-license"
+    >
+      SonarSource
+    </span>
+    <span
+      className="update-center-meta-data-issue-tracker"
+    >
+      <a
+        href="https://jira.sonarsource.com/browse/SONARJAVA"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        Issue Tracker
+      </a>
+    </span>
+    <span
+      className="update-center-meta-data-supported"
+    >
+      Supported by SonarSource
+    </span>
+  </div>
+  <MetaDataVersions
+    versions={
+      Array [
+        Object {
+          "archived": false,
+          "changeLogUrl": "https://example.com/sonar-java-plugin/release",
+          "compatibility": "6.7",
+          "date": "2019-05-31",
+          "downloadURL": "https://example.com/sonar-java-plugin-5.13.0.18197.jar",
+          "version": "2.0",
+        },
+        Object {
+          "archived": true,
+          "changeLogUrl": "https://example.com/sonar-java-plugin/release",
+          "compatibility": "6.7",
+          "date": "2019-05-31",
+          "downloadURL": "https://example.com/sonar-java-plugin-5.13.0.18197.jar",
+          "version": "1.0",
+        },
+      ]
+    }
+  />
+</div>
+`;
+
+exports[`should render correctly with organization 1`] = `
+<div
+  className="update-center-meta-data"
+>
+  <div
+    className="update-center-meta-data-header"
+  >
+    <span
+      className="update-center-meta-data-vendor"
+    >
+      By 
+      <a
+        href="test-org-url"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        test-org
+      </a>
+    </span>
+    <span
+      className="update-center-meta-data-license"
+    >
+      SonarSource
+    </span>
+    <span
+      className="update-center-meta-data-issue-tracker"
+    >
+      <a
+        href="https://jira.sonarsource.com/browse/SONARJAVA"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        Issue Tracker
+      </a>
+    </span>
+    <span
+      className="update-center-meta-data-supported"
+    >
+      Supported by SonarSource
+    </span>
+  </div>
+  <MetaDataVersions
+    versions={
+      Array [
+        Object {
+          "archived": false,
+          "changeLogUrl": "https://example.com/sonar-java-plugin/release",
+          "compatibility": "6.7",
+          "date": "2019-05-31",
+          "downloadURL": "https://example.com/sonar-java-plugin-5.13.0.18197.jar",
+          "version": "2.0",
+        },
+        Object {
+          "archived": true,
+          "changeLogUrl": "https://example.com/sonar-java-plugin/release",
+          "compatibility": "6.7",
+          "date": "2019-05-31",
+          "downloadURL": "https://example.com/sonar-java-plugin-5.13.0.18197.jar",
+          "version": "1.0",
+        },
+      ]
+    }
+  />
+</div>
+`;

--- a/components/ui/update-center/__tests__/__snapshots__/MetaDataVersion-test.tsx.snap
+++ b/components/ui/update-center/__tests__/__snapshots__/MetaDataVersion-test.tsx.snap
@@ -1,0 +1,113 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render correctly 1`] = `
+<div
+  className="update-center-meta-data-version"
+>
+  <div
+    className="update-center-meta-data-version-version"
+  >
+    5.13
+  </div>
+  <div
+    className="update-center-meta-data-version-release-info"
+  >
+    <time
+      className="update-center-meta-data-version-release-date"
+    >
+      2019-05-31
+    </time>
+    <span
+      className="update-center-meta-data-version-compatibility"
+    >
+      6.7
+    </span>
+  </div>
+  <div
+    className="update-center-meta-data-version-release-links"
+  >
+    <span
+      className="update-center-meta-data-version-download"
+      key="0"
+    >
+      <a
+        href="https://example.com/sonar-java-plugin-5.13.0.18197.jar"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        Download
+      </a>
+    </span>
+    <span
+      className="update-center-meta-data-version-release-notes"
+    >
+      <a
+        href="https://example.com/sonar-java-plugin/release"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        Release notes
+      </a>
+    </span>
+  </div>
+</div>
+`;
+
+exports[`should render correctly: with advanced downloadUrl 1`] = `
+<div
+  className="update-center-meta-data-version"
+>
+  <div
+    className="update-center-meta-data-version-version"
+  >
+    5.13
+  </div>
+  <div
+    className="update-center-meta-data-version-release-info"
+  >
+    <time
+      className="update-center-meta-data-version-release-date"
+    >
+      2019-05-31
+    </time>
+    <span
+      className="update-center-meta-data-version-compatibility"
+    >
+      6.7
+    </span>
+  </div>
+  <div
+    className="update-center-meta-data-version-release-links"
+  >
+    <span
+      className="update-center-meta-data-version-release-notes"
+    >
+      <a
+        href="https://example.com/sonar-java-plugin/release"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        Release notes
+      </a>
+    </span>
+  </div>
+</div>
+`;
+
+exports[`should render correctly: with very few info 1`] = `
+<div
+  className="update-center-meta-data-version"
+>
+  <div
+    className="update-center-meta-data-version-version"
+  >
+    2.0
+  </div>
+  <div
+    className="update-center-meta-data-version-release-info"
+  />
+  <div
+    className="update-center-meta-data-version-release-links"
+  />
+</div>
+`;

--- a/components/ui/update-center/__tests__/__snapshots__/MetaDataVersions-test.tsx.snap
+++ b/components/ui/update-center/__tests__/__snapshots__/MetaDataVersions-test.tsx.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render correctly 1`] = `
+<div
+  className="update-center-meta-data-versions"
+>
+  <button
+    className="update-center-meta-data-versions-show-more"
+    onClick={[Function]}
+    type="button"
+  >
+    Show more versions
+  </button>
+  <MetaDataVersion
+    key="3.0"
+    versionInformation={
+      Object {
+        "archived": false,
+        "changeLogUrl": "https://example.com/sonar-java-plugin/release",
+        "compatibility": "6.7",
+        "date": "2019-05-31",
+        "downloadURL": "https://example.com/sonar-java-plugin-5.13.0.18197.jar",
+        "version": "3.0",
+      }
+    }
+  />
+</div>
+`;

--- a/components/ui/update-center/mocks/update-center-metadata.ts
+++ b/components/ui/update-center/mocks/update-center-metadata.ts
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/components/ui/update-center/mocks/update-center-metadata.ts
+++ b/components/ui/update-center/mocks/update-center-metadata.ts
@@ -1,0 +1,58 @@
+/*
+ * Sonar UI Common
+ * Copyright (C) 2019-2019 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { MetaDataInformation, MetaDataVersionInformation } from '../update-center-metadata';
+
+export function mockMetaDataVersionInformation(
+  overrides?: Partial<MetaDataVersionInformation>
+): MetaDataVersionInformation {
+  return {
+    version: '5.13',
+    date: '2019-05-31',
+    compatibility: '6.7',
+    archived: false,
+    downloadURL: 'https://example.com/sonar-java-plugin-5.13.0.18197.jar',
+    changeLogUrl: 'https://example.com/sonar-java-plugin/release',
+    ...overrides
+  };
+}
+
+export function mockMetaDataInformation(
+  overrides?: Partial<MetaDataInformation>
+): MetaDataInformation {
+  return {
+    name: 'SonarJava',
+    key: 'java',
+    isSonarSourceCommercial: true,
+    organization: {
+      name: 'SonarSource',
+      url: 'http://www.sonarsource.com/'
+    },
+    category: 'Languages',
+    license: 'SonarSource',
+    issueTrackerURL: 'https://jira.sonarsource.com/browse/SONARJAVA',
+    sourcesURL: 'https://github.com/SonarSource/sonar-java',
+    versions: [
+      mockMetaDataVersionInformation({ version: '2.0' }),
+      mockMetaDataVersionInformation({ version: '1.0', archived: true })
+    ],
+    ...overrides
+  };
+}

--- a/components/ui/update-center/update-center-metadata.ts
+++ b/components/ui/update-center/update-center-metadata.ts
@@ -1,0 +1,49 @@
+/*
+ * Sonar UI Common
+ * Copyright (C) 2019-2019 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+export interface MetaDataInformation {
+  category?: string;
+  isSonarSourceCommercial?: boolean;
+  issueTrackerURL?: string;
+  key?: string;
+  license?: string;
+  name: string;
+  organization?: {
+    name: string;
+    url?: string;
+  };
+  sourcesURL?: string;
+  versions?: MetaDataVersionInformation[];
+}
+
+export interface MetaDataVersionInformation {
+  archived?: boolean;
+  changeLogUrl?: string;
+  compatibility?: string;
+  date?: string;
+  description?: string;
+  downloadURL?: string | AdvancedDownloadUrl[];
+  version: string;
+}
+
+export interface AdvancedDownloadUrl {
+  label?: string;
+  url: string;
+}

--- a/components/ui/update-center/update-center-metadata.ts
+++ b/components/ui/update-center/update-center-metadata.ts
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/config/jest/CSSStub.js
+++ b/config/jest/CSSStub.js
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or
@@ -18,4 +18,3 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 module.exports = {};
-

--- a/config/jest/FileStub.js
+++ b/config/jest/FileStub.js
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/config/jest/SetupEnzyme.js
+++ b/config/jest/SetupEnzyme.js
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/config/jest/SetupTestEnvironment.js
+++ b/config/jest/SetupTestEnvironment.js
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/helpers/__tests__/colors-test.ts
+++ b/helpers/__tests__/colors-test.ts
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/helpers/__tests__/dates-test.ts
+++ b/helpers/__tests__/dates-test.ts
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/helpers/__tests__/handleRequiredAuthentication-test.ts
+++ b/helpers/__tests__/handleRequiredAuthentication-test.ts
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/helpers/__tests__/l10n-test.ts
+++ b/helpers/__tests__/l10n-test.ts
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/helpers/__tests__/measures-test.ts
+++ b/helpers/__tests__/measures-test.ts
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/helpers/__tests__/path-test.ts
+++ b/helpers/__tests__/path-test.ts
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/helpers/__tests__/query-test.ts
+++ b/helpers/__tests__/query-test.ts
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/helpers/__tests__/request-test.ts
+++ b/helpers/__tests__/request-test.ts
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/helpers/__tests__/scrolling-test.ts
+++ b/helpers/__tests__/scrolling-test.ts
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/helpers/__tests__/strings-test.ts
+++ b/helpers/__tests__/strings-test.ts
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/helpers/__tests__/urls-test.ts
+++ b/helpers/__tests__/urls-test.ts
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/helpers/colors.ts
+++ b/helpers/colors.ts
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/helpers/cookies.ts
+++ b/helpers/cookies.ts
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/helpers/csv.ts
+++ b/helpers/csv.ts
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/helpers/dates.ts
+++ b/helpers/dates.ts
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/helpers/getHistory.ts
+++ b/helpers/getHistory.ts
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/helpers/handleRequiredAuthentication.ts
+++ b/helpers/handleRequiredAuthentication.ts
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/helpers/keycodes.ts
+++ b/helpers/keycodes.ts
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/helpers/l10n.ts
+++ b/helpers/l10n.ts
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/helpers/measures.ts
+++ b/helpers/measures.ts
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/helpers/pages.ts
+++ b/helpers/pages.ts
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/helpers/path.ts
+++ b/helpers/path.ts
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/helpers/query.ts
+++ b/helpers/query.ts
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/helpers/ratings.ts
+++ b/helpers/ratings.ts
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/helpers/request.ts
+++ b/helpers/request.ts
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/helpers/scrolling.ts
+++ b/helpers/scrolling.ts
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/helpers/search.tsx
+++ b/helpers/search.tsx
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/helpers/storage.ts
+++ b/helpers/storage.ts
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/helpers/strings.ts
+++ b/helpers/strings.ts
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/helpers/testUtils.ts
+++ b/helpers/testUtils.ts
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/helpers/types.ts
+++ b/helpers/types.ts
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/helpers/urls.ts
+++ b/helpers/urls.ts
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,6 +1,6 @@
 /*
  * Sonar UI Common
- * Copyright (C) 2019-2019 SonarSource SA
+ * Copyright (C) 2019-2020 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or


### PR DESCRIPTION
This is the better way I came up to with to share properly this component between our static and embedded documentation. Since now it'll be available in the embedded documentation, it'll surely interest you SC guys as well.

**Checklist**

* [ ] Functional validation
* [ ] Documentation update
* [x] Update changelog

