### PR TITLE
Fix for update-center's component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix for update-center's component that was failing in the context of gatsby 
+
 ## 0.0.56
 
 - Add update-center's component used in documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.0.57
+
 - Fix for update-center's component that was failing in the context of gatsby 
 
 ## 0.0.56

--- a/components/ui/update-center/MetaData.tsx
+++ b/components/ui/update-center/MetaData.tsx
@@ -19,7 +19,6 @@
  */
 
 import * as React from 'react';
-import { getJSON } from '../../../helpers/request';
 import './MetaData.css';
 import MetaDataVersions from './MetaDataVersions';
 import { MetaDataInformation } from './update-center-metadata';
@@ -55,14 +54,25 @@ export default class MetaData extends React.Component<Props, State> {
     const { updateCenterKey } = this.props;
 
     if (updateCenterKey) {
-      getJSON(`https://update.sonarsource.org/${updateCenterKey}.json`).then(
-        (data: MetaDataInformation) => {
+      window
+        .fetch(`https://update.sonarsource.org/${updateCenterKey}.json`)
+        .then((response: Response) => {
+          if (response.status >= 200 && response.status < 300) {
+            return response.json();
+          } else {
+            return Promise.reject(response);
+          }
+        })
+        .then(data => {
           if (this.mounted) {
             this.setState({ data });
           }
-        },
-        () => this.setState({ data: undefined })
-      );
+        })
+        .catch(() => {
+          if (this.mounted) {
+            this.setState({ data: undefined });
+          }
+        });
     } else {
       this.setState({ data: undefined });
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sonar-ui-common",
-  "version": "0.0.56",
+  "version": "0.0.57",
   "description": "Common UI lib for SonarQube and SonarCloud",
   "repository": "SonarSource/sonar-ui-common",
   "license": "LGPL-3.0",


### PR DESCRIPTION
I thought that using our getJSON utility was a good idea, but it turns out that it is located in a module that import 'l10n', which do some magic on the `window` object, magic that fails in the context of Gatsby ... So back to `window.fetch`.