### PR TITLE
SONAR-12256 Improve percentage formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- SONAR-12256 Improve percentage formatting with trailing zeros
+
 ## 0.0.57
 
 - Fix for update-center's component that was failing in the context of gatsby 

--- a/helpers/__tests__/measures-test.ts
+++ b/helpers/__tests__/measures-test.ts
@@ -98,6 +98,18 @@ describe('#formatMeasure()', () => {
     expect(formatMeasure(50.89, 'PERCENT', { decimals: 1 })).toBe('50.9%');
     expect(formatMeasure(50.89, 'PERCENT', { decimals: 2 })).toBe('50.89%');
     expect(formatMeasure(50.89, 'PERCENT', { decimals: 3 })).toBe('50.890%');
+    expect(formatMeasure(50, 'PERCENT', { decimals: 0, omitExtraDecimalZeros: true })).toBe(
+      '50.0%'
+    );
+    expect(formatMeasure(50, 'PERCENT', { decimals: 1, omitExtraDecimalZeros: true })).toBe(
+      '50.0%'
+    );
+    expect(formatMeasure(50, 'PERCENT', { decimals: 3, omitExtraDecimalZeros: true })).toBe(
+      '50.0%'
+    );
+    expect(formatMeasure(50.89, 'PERCENT', { decimals: 3, omitExtraDecimalZeros: true })).toBe(
+      '50.89%'
+    );
   });
 
   it('should format WORK_DUR', () => {

--- a/helpers/measures.ts
+++ b/helpers/measures.ts
@@ -173,14 +173,27 @@ function floatFormatter(value: string | number): string {
   return numberFormatter(value, 1, 5);
 }
 
-function percentFormatter(value: string | number, options: { decimals?: number } = {}): string {
+function percentFormatter(
+  value: string | number,
+  { decimals, omitExtraDecimalZeros }: { decimals?: number; omitExtraDecimalZeros?: boolean } = {}
+): string {
   if (typeof value === 'string') {
     value = parseFloat(value);
   }
-  if (options.decimals) {
-    return `${numberFormatter(value, options.decimals)}%`;
+  if (value === 100) {
+    return '100%';
+  } else if (omitExtraDecimalZeros && decimals) {
+    // If omitExtraDecimalZeros is true, all trailing decimal 0s will be removed,
+    // except for the first decimal.
+    // E.g. for decimals=3:
+    // - omitExtraDecimalZeros: false, value: 45.450 => 45.450
+    // - omitExtraDecimalZeros: true, value: 45.450 => 45.45
+    // - omitExtraDecimalZeros: false, value: 85 => 85.000
+    // - omitExtraDecimalZeros: true, value: 85 => 85.0
+    return `${numberFormatter(value, 1, decimals)}%`;
+  } else {
+    return `${numberFormatter(value, decimals || 1)}%`;
   }
-  return value === 100 ? '100%' : `${numberFormatter(value, 1)}%`;
 }
 
 function ratingFormatter(value: string | number): string {


### PR DESCRIPTION
Currently, we go through a lot of trouble to handle percentages rounding (see [this PR](https://github.com/SonarSource/sonar-enterprise/pull/2109)). This is an attempt to both fix this for PRs (where the issue still exists), and to simplify this whole approach.

The reasoning is, we round to a single decimal for "aesthetics", even though we always show 2 in failing conditions. Suggestion: let's always show 2, _unless_ there's a trailing zero, and trim it off. If there's a trailing double-zero, we only show 1 zero. So it should behave as expected, except it won't round by default anymore (always 2 decimals).

In this example, new coverage is at 91.69%, and overall is at 84.70%:

![roundme](https://user-images.githubusercontent.com/45544358/79243431-e666ed80-7e75-11ea-8dd3-9bbda6461e3d.gif)

See https://github.com/SonarSource/sonar-enterprise/pull/2698 for the fix on sonar-enterprise.

**Checklist**

* [x] Functional validation
* [ ] ~Documentation update~
* [x] Update changelog

