### PR TITLE
Add setReactDomContainer init function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add new 'setReactDomContainer' init function
+
 ## 1.0.0
 
 - Update version of Typescript, Eslint and Prettier

--- a/README.md
+++ b/README.md
@@ -31,12 +31,14 @@ import Initializer from 'sonar-ui-common/helpers/init';
 Initializer
   .setUrlContext('/sonarqube')  // [required] Provide the web context
   .setMessages({})              // [optional] Provide your l10n bundle, retrieved anyway you want (from ws call, localstorage, json file...)
-  .setLocale('en');             // [optional] Provide the language of your l10n bundle
+  .setLocale('en')              // [optional] Provide the language of your l10n bundle
+  .setReactDomContainer('#app');// [optional] Is a css selector of the DOM node where the React app is attached. Defaults to '#content'.
 ```
 
-The urlContext MUST be set before using the library or it will throw an Error.
+The `urlContext` MUST be set before using the library or it will throw an Error.
 The l10n data can be set asynchronously, i.e. `messages` and `locale` can stay `undefined` if they need to be updated later.
 The default messages contain only a default error message, and the default locale is 'en'.
+The `reactDomContainerSelector` is completely optional and defaults to `#content` for backward compatility, it won't display any warning or error if not initialized at all.
 
 ## Styled-components
 

--- a/components/controls/Modal.tsx
+++ b/components/controls/Modal.tsx
@@ -20,9 +20,10 @@
 import * as classNames from 'classnames';
 import * as React from 'react';
 import * as ReactModal from 'react-modal';
+import { getReactDomContainerSelector } from '../../helpers/init';
 import './Modal.css';
 
-ReactModal.setAppElement('#content');
+ReactModal.setAppElement(getReactDomContainerSelector());
 
 export interface ModalProps {
   children: React.ReactNode;

--- a/helpers/__tests__/init-test.ts
+++ b/helpers/__tests__/init-test.ts
@@ -23,6 +23,7 @@ import Initializer, {
   DEFAULT_MESSAGES,
   getLocale,
   getMessages,
+  getReactDomContainerSelector,
   getUrlContext,
 } from '../init';
 
@@ -34,7 +35,7 @@ beforeEach(() => {
 });
 
 afterAll(() => {
-  Initializer.setLocale('en').setMessages({}).setUrlContext('');
+  Initializer.setLocale('en').setMessages({}).setUrlContext('').setReactDomContainer(undefined);
   console.warn = originalConsoleWarn;
 });
 
@@ -57,15 +58,26 @@ it('should throw when trying to get a value without initializing first', () => {
   );
 });
 
-it('should return the locale, messages and context', () => {
+it('should return the initialized values', () => {
   const locale = 'ru';
   const messages = { any: 'Any' };
   const urlContext = '/context';
-  Initializer.setLocale(locale).setMessages(messages).setUrlContext(urlContext);
+  const reactDomContainerSelector = '#custom';
+  Initializer.setLocale(locale)
+    .setMessages(messages)
+    .setUrlContext(urlContext)
+    .setReactDomContainer(reactDomContainerSelector);
 
   expect(getLocale()).toBe(locale);
   expect(getMessages()).toBe(messages);
   expect(getUrlContext()).toBe(urlContext);
+  expect(getReactDomContainerSelector()).toBe(reactDomContainerSelector);
+  expect(console.warn).not.toBeCalled();
+});
 
+it('should have a default react dom container selector without warning', () => {
+  Initializer.setReactDomContainer(undefined);
+
+  expect(getReactDomContainerSelector()).toBe('#content');
   expect(console.warn).not.toBeCalled();
 });

--- a/helpers/init.ts
+++ b/helpers/init.ts
@@ -22,6 +22,7 @@ import type { Messages } from './l10n';
 let urlContext: string; // Is the base path (web context) in SQ
 let messages: Messages | undefined;
 let locale: string | undefined;
+let reactDomContainerSelector: string | undefined; // CSS selector of the DOM node where the React App is attached
 
 export const IS_SSR = typeof window === 'undefined';
 export const DEFAULT_LOCALE = 'en';
@@ -44,6 +45,10 @@ export default {
     messages = newMessages;
     return this;
   },
+  setReactDomContainer(nodeSelector: string) {
+    reactDomContainerSelector = nodeSelector;
+    return this;
+  },
 };
 
 export function getMessages() {
@@ -60,6 +65,10 @@ export function getLocale() {
     return DEFAULT_LOCALE;
   }
   return locale;
+}
+
+export function getReactDomContainerSelector() {
+  return reactDomContainerSelector || '#content';
 }
 
 export function getUrlContext() {


### PR DESCRIPTION
While switching to gatsby we noticed that this initialization function was missing. It allows to have a different selector for the dom node used to initialize the react app.
The default to "#content" is kept and no errors or warning are thrown by this one so that it's not needed to initialize for all other projects than SC.

**Checklist**

* [x] Functional validation
* [x] Documentation update
* [x] Update changelog

