### PR TITLE
Avoid having the mock theme in the packaged bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Remove the mocked theme from the bundled package, `SetupTestEnvironment.js` files need to be updated in projects that use SUC (see the readme).
+
 ## 1.0.1
 
 - Add new 'setReactDomContainer' init function

--- a/README.md
+++ b/README.md
@@ -8,24 +8,15 @@ It is available on the npm registry: https://www.npmjs.com/package/sonar-ui-comm
 
 There is no index file so you have to import components with their path like this :
 
-```Ts
+```ts
 import BugIcon from 'sonar-ui-common/components/icons/BugIcon';
 ```
 
-Ambients types are available in the `types.d.ts`, to benefit from them in your project you include it in your `tsconfig.json` file, example:
-
-```json
-{
-  "compilerOptions": {
-    /*...*/
-  },
-  "include": ["./src/main/js/**/*", "node_modules/sonar-ui-common/types.d.ts"]
-}
-```
+### Initialize it
 
 To use the library, it should first be initialized by these methods:
 
-```Ts
+```ts
 import Initializer from 'sonar-ui-common/helpers/init';
 
 Initializer
@@ -39,6 +30,37 @@ The `urlContext` MUST be set before using the library or it will throw an Error.
 The l10n data can be set asynchronously, i.e. `messages` and `locale` can stay `undefined` if they need to be updated later.
 The default messages contain only a default error message, and the default locale is 'en'.
 The `reactDomContainerSelector` is completely optional and defaults to `#content` for backward compatility, it won't display any warning or error if not initialized at all.
+
+### Ambient types
+
+Ambients types are available in the `types.d.ts`, to benefit from them in your project you include it in your `tsconfig.json` file, example:
+
+```json
+{
+  "compilerOptions": {
+    /*...*/
+  },
+  "include": ["./src/main/js/**/*", "node_modules/sonar-ui-common/types.d.ts"]
+}
+```
+
+### Run test that use Sonar-ui-common components
+
+To ease testing your components that depends on Sonar-ui-common components you should initialize Sonar-ui-common
+in your test runner. Create a `SetupSUC.ts` file that you add in the `setupFiles` config of jest, with a similar content:
+
+```ts
+import ThemeContext from 'sonar-ui-common/components/theme';
+import Initializer, { DEFAULT_LOCALE } from 'sonar-ui-common/helpers/init';
+import theme from '../../src/app/theme';
+
+Initializer.setLocale(DEFAULT_LOCALE).setMessages({}).setUrlContext('');
+
+// Hack : override the default value of the context used for theme by emotion
+// This allows tests to get the theme value without specifiying a theme provider
+ThemeContext['_currentValue'] = theme;
+ThemeContext['_currentValue2'] = theme;
+```
 
 ## Styled-components
 

--- a/components/charts/__tests__/ColorGradientLegend-test.tsx
+++ b/components/charts/__tests__/ColorGradientLegend-test.tsx
@@ -20,11 +20,10 @@
 import { scaleLinear } from 'd3-scale';
 import { shallow } from 'enzyme';
 import * as React from 'react';
-// eslint-disable-next-line jest/no-mocks-import
-import { mockedTheme } from '../../__mocks__/mockedTheme';
+import testTheme from '../../../config/jest/testTheme';
 import ColorGradientLegend from '../ColorGradientLegend';
 
-const { colors } = mockedTheme;
+const { colors } = testTheme;
 const COLORS = [colors.green, colors.lightGreen, colors.yellow, colors.orange, colors.red];
 
 it('should render properly', () => {

--- a/components/charts/__tests__/ZoomTimeLine-test.tsx
+++ b/components/charts/__tests__/ZoomTimeLine-test.tsx
@@ -20,8 +20,7 @@
 
 import { shallow } from 'enzyme';
 import * as React from 'react';
-// eslint-disable-next-line jest/no-mocks-import
-import { mockedTheme } from '../../__mocks__/mockedTheme';
+import testTheme from '../../../config/jest/testTheme';
 import ZoomTimeLine from '../ZoomTimeLine';
 
 const series = [
@@ -59,7 +58,7 @@ it('should render a leak period', () => {
     shallowRender({ leakPeriodDate: new Date('2020-01-01') })
       .find('ContextConsumer')
       .dive()
-      .find(`rect[fill="${mockedTheme.colors.leakPrimaryColor}"]`)
+      .find(`rect[fill="${testTheme.colors.leakPrimaryColor}"]`)
       .exists()
   ).toBe(true);
 });

--- a/components/controls/__tests__/BackButton-test.tsx
+++ b/components/controls/__tests__/BackButton-test.tsx
@@ -19,10 +19,9 @@
  */
 import { shallow } from 'enzyme';
 import * as React from 'react';
+import testTheme from '../../../config/jest/testTheme';
 import { click } from '../../../helpers/testUtils';
 import { ThemeProvider } from '../../theme';
-// eslint-disable-next-line jest/no-mocks-import
-import { mockedTheme } from '../../__mocks__/mockedTheme';
 import BackButton from '../BackButton';
 
 it('should render properly', () => {
@@ -43,7 +42,7 @@ function shallowRender(props: Partial<BackButton['props']> = {}) {
   return shallow<BackButton>(<BackButton onClick={jest.fn()} {...props} />, {
     wrappingComponent: ThemeProvider,
     wrappingComponentProps: {
-      theme: mockedTheme,
+      theme: testTheme,
     },
   });
 }

--- a/components/controls/__tests__/GlobalMessages-test.tsx
+++ b/components/controls/__tests__/GlobalMessages-test.tsx
@@ -20,9 +20,7 @@
 import { shallow } from 'enzyme';
 import { matchers } from 'jest-emotion';
 import * as React from 'react';
-// mockedTheme is in fact the default theme
-// eslint-disable-next-line jest/no-mocks-import
-import { mockedTheme } from '../../__mocks__/mockedTheme';
+import testTheme from '../../../config/jest/testTheme';
 import GlobalMessages, { GlobalMessagesProps } from '../GlobalMessages';
 
 expect.extend(matchers);
@@ -42,12 +40,12 @@ it('should render with correct css', () => {
   expect(wrapper.render()).toMatchSnapshot();
   expect(wrapper.find('GlobalMessage').first().render()).toHaveStyleRule(
     'background-color',
-    mockedTheme.colors.red
+    testTheme.colors.red
   );
 
   expect(wrapper.find('GlobalMessage').last().render()).toHaveStyleRule(
     'background-color',
-    mockedTheme.colors.green
+    testTheme.colors.green
   );
 });
 

--- a/components/controls/__tests__/HelpTooltip-test.tsx
+++ b/components/controls/__tests__/HelpTooltip-test.tsx
@@ -20,16 +20,15 @@
 
 import { shallow } from 'enzyme';
 import * as React from 'react';
+import testTheme from '../../../config/jest/testTheme';
 import { ThemeProvider } from '../../theme';
-// eslint-disable-next-line jest/no-mocks-import
-import { mockedTheme } from '../../__mocks__/mockedTheme';
 import HelpTooltip from '../HelpTooltip';
 
 it('should render properly', () => {
   const wrapper = shallow(<HelpTooltip overlay={<div className="my-overlay" />} />, {
     wrappingComponent: ThemeProvider,
     wrappingComponentProps: {
-      theme: mockedTheme,
+      theme: testTheme,
     },
   });
   expect(wrapper).toMatchSnapshot();

--- a/components/controls/__tests__/ReloadButton-test.tsx
+++ b/components/controls/__tests__/ReloadButton-test.tsx
@@ -20,10 +20,9 @@
 
 import { shallow } from 'enzyme';
 import * as React from 'react';
+import testTheme from '../../../config/jest/testTheme';
 import { click } from '../../../helpers/testUtils';
 import { ThemeProvider } from '../../theme';
-// eslint-disable-next-line jest/no-mocks-import
-import { mockedTheme } from '../../__mocks__/mockedTheme';
 import ReloadButton from '../ReloadButton';
 
 it('should render properly', () => {
@@ -44,7 +43,7 @@ function shallowRender(props: Partial<ReloadButton['props']> = {}) {
   return shallow<ReloadButton>(<ReloadButton onClick={jest.fn()} {...props} />, {
     wrappingComponent: ThemeProvider,
     wrappingComponentProps: {
-      theme: mockedTheme,
+      theme: testTheme,
     },
   });
 }

--- a/components/theme.ts
+++ b/components/theme.ts
@@ -26,9 +26,6 @@ import {
   withTheme,
 } from 'emotion-theming';
 import * as React from 'react';
-// mockedTheme is in fact the default theme
-// eslint-disable-next-line jest/no-mocks-import
-import { mockedTheme } from './__mocks__/mockedTheme';
 
 export interface Theme {
   colors: T.Dict<string>;
@@ -44,14 +41,6 @@ export interface ThemedProps {
 }
 
 const ThemeContext = EmotionThemeContext as React.Context<Theme>;
-
-// Hack : override the default value of the context used for theme by emotion
-// As we can't pass a default value when it is constructed
-// This allows outside tests to get the mocked theme value without specifiying a theme provider
-if (process.env.NODE_ENV === 'test') {
-  (ThemeContext as any)['_currentValue'] = mockedTheme;
-  (ThemeContext as any)['_currentValue2'] = mockedTheme;
-}
 
 export const styled = emotionStyled as CreateStyled<Theme>;
 export const ThemeConsumer = ThemeContext.Consumer;

--- a/config/jest/SetupSUC.ts
+++ b/config/jest/SetupSUC.ts
@@ -17,6 +17,13 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-import Initializer from '../../helpers/init';
+import ThemeContext from '../../components/theme';
+import Initializer, { DEFAULT_LOCALE } from '../../helpers/init';
+import testTheme from './testTheme';
 
-Initializer.setLocale('en').setMessages({}).setUrlContext('');
+Initializer.setLocale(DEFAULT_LOCALE).setMessages({}).setUrlContext('');
+
+// Hack : override the default value of the context used for theme by emotion
+// This allows tests to get the theme value without specifiying a theme provider
+ThemeContext['_currentValue'] = testTheme;
+ThemeContext['_currentValue2'] = testTheme;

--- a/config/jest/testTheme.ts
+++ b/config/jest/testTheme.ts
@@ -17,11 +17,9 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-
-// IMPORTANT: any change in this file requires restart of the dev server
 const grid = 8;
 
-export const mockedTheme = {
+export default {
   colors: {
     blue: '#4b9fd5',
     veryLightBlue: '#f2faff',


### PR DESCRIPTION
The mock theme has been bundled until now inside the package on npm and even up in the SC (and probably SQ) build too.

This PR removes it from there and move/rename the theme to the test config instead of mocks because it's not mocking anything.

**Checklist**

* [ ] Functional validation
* [ ] Documentation update
* [ ] Update changelog - didn't add anything since it should not have impact outside...

