### PR TITLE
Improve disabled select option style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- SC-737 Improve disabled select option style
+
 ## 1.0.2
 
 - Remove the mocked theme from the bundled package, `SetupTestEnvironment.js` files need to be updated in projects that use SUC (see the readme).

--- a/components/controls/Select.css
+++ b/components/controls/Select.css
@@ -339,7 +339,8 @@
 
 .Select-option.is-disabled {
   cursor: default;
-  opacity: 0.5;
+  opacity: 0.4;
+  font-style: italic;
 }
 
 .Select-noresults {


### PR DESCRIPTION
This change improves the visual style of disabled options in select elements with a better distinction between these and regular options.

This is related to this PR in sonarcloud: https://github.com/SonarSource/sonarcloud-core/pull/927

**Checklist**

* [ ] Functional validation
* [ ] Documentation update
* [ ] Update changelog

