### PR TITLE
SONAR-13391 Fix Activity Chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- SONAR-13391 Fix Activity Chart
+
 ## 1.0.5
 
 - SONAR-13479 Add a Chevrons icon
@@ -28,10 +30,10 @@
 - Update version of Typescript, Eslint and Prettier
 
 #### Breaking changes
+
 - Drop legacy lazyLoad function
 - SC-1951 Add sonar-ui-common initialization function for l10n messages and url context
   - Drop all the network and caching functions from `helpers/l10n.ts`
-
 
 ## 0.0.58
 
@@ -40,7 +42,7 @@
 
 ## 0.0.57
 
-- Fix for update-center's component that was failing in the context of gatsby 
+- Fix for update-center's component that was failing in the context of gatsby
 
 ## 0.0.56
 

--- a/components/charts/AdvancedTimeline.tsx
+++ b/components/charts/AdvancedTimeline.tsx
@@ -359,7 +359,12 @@ export default class AdvancedTimeline extends React.PureComponent<Props, State> 
     const { xScale, yScale } = this.state;
     const yRange = yScale.range();
     const xRange = xScale.range();
-    const leakWidth = xRange[xRange.length - 1] - xScale(leakPeriodDate);
+
+    // truncate leak to start of chart to prevent weird visual artifacts when too far left
+    // (occurs when leak starts a long time before first analysis)
+    const leakStart = Math.max(xScale(leakPeriodDate), xRange[0]);
+
+    const leakWidth = xRange[xRange.length - 1] - leakStart;
     if (leakWidth < 0) {
       return null;
     }
@@ -371,7 +376,7 @@ export default class AdvancedTimeline extends React.PureComponent<Props, State> 
             fill={theme.colors.leakPrimaryColor}
             height={yRange[0] - yRange[yRange.length - 1]}
             width={leakWidth}
-            x={xScale(leakPeriodDate)}
+            x={leakStart}
             y={yRange[yRange.length - 1]}
           />
         )}

--- a/components/charts/__tests__/__snapshots__/AdvancedTimeline-test.tsx.snap
+++ b/components/charts/__tests__/__snapshots__/AdvancedTimeline-test.tsx.snap
@@ -189,22 +189,104 @@ exports[`should render correctly 1`] = `
     </g>
     <g
       transform="translate(0, 20)"
-    />
+    >
+      <text
+        className="line-chart-tick"
+        key="0"
+        textAnchor="end"
+        transform="rotate(-35, 1.875, 40)"
+        x={1.875}
+        y={40}
+      >
+        October
+      </text>
+      <text
+        className="line-chart-tick"
+        key="1"
+        textAnchor="end"
+        transform="rotate(-35, 5.625, 40)"
+        x={5.625}
+        y={40}
+      >
+        06 AM
+      </text>
+      <text
+        className="line-chart-tick"
+        key="2"
+        textAnchor="end"
+        transform="rotate(-35, 9.375, 40)"
+        x={9.375}
+        y={40}
+      >
+        12 PM
+      </text>
+      <text
+        className="line-chart-tick"
+        key="3"
+        textAnchor="end"
+        transform="rotate(-35, 13.125, 40)"
+        x={13.125}
+        y={40}
+      >
+        06 PM
+      </text>
+      <text
+        className="line-chart-tick"
+        key="4"
+        textAnchor="end"
+        transform="rotate(-35, 16.875, 40)"
+        x={16.875}
+        y={40}
+      >
+        Wed 02
+      </text>
+      <text
+        className="line-chart-tick"
+        key="5"
+        textAnchor="end"
+        transform="rotate(-35, 20.625, 40)"
+        x={20.625}
+        y={40}
+      >
+        06 AM
+      </text>
+      <text
+        className="line-chart-tick"
+        key="6"
+        textAnchor="end"
+        transform="rotate(-35, 24.375, 40)"
+        x={24.375}
+        y={40}
+      >
+        12 PM
+      </text>
+      <text
+        className="line-chart-tick"
+        key="7"
+        textAnchor="end"
+        transform="rotate(-35, 28.125, 40)"
+        x={28.125}
+        y={40}
+      >
+        06 PM
+      </text>
+    </g>
     <g>
       <path
         className="line-chart-path line-chart-path-0"
-        d="MNaN,26.66666666666667LNaN,13.333333333333336"
+        d="M0,26.66666666666667L15,13.333333333333336"
         key="test-1"
       />
       <path
         className="line-chart-path line-chart-path-1"
-        d="MNaN,0Z"
+        d="M30,0Z"
         key="test-2"
       />
     </g>
     <g>
       <circle
         className="line-chart-dot line-chart-dot-1"
+        cx={30}
         cy={0}
         key="test-20"
         r="2"


### PR DESCRIPTION
We added a new setting for the New Code which makes it possible for the leak to start before the first analysis. This breaks the Activity chart when the fork point is too old.
What happens is the leak `rect` becomes so big it generates some weird visual artifacts.

**Checklist**

* [x] Functional validation
* [ ] Documentation update
* [x] Update changelog

