### PR TITLE
Add POST JSON body request support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add POST JSON body request support
+
 ## 1.0.9
 
 - Allow to pass arial attributes prop to icons

--- a/helpers/__tests__/request-test.ts
+++ b/helpers/__tests__/request-test.ts
@@ -30,6 +30,7 @@ import {
   parseText,
   post,
   postJSON,
+  postJSONBody,
   requestTryAndRepeatUntil,
 } from '../request';
 
@@ -142,6 +143,30 @@ describe('postJSON', () => {
     expect(window.fetch).toBeCalledWith(
       url,
       expect.objectContaining({ body: 'data=test', method: 'POST' })
+    );
+  });
+});
+
+describe('postJSONBody', () => {
+  it('should post without parameters and get json', async () => {
+    const response = mockResponse();
+    window.fetch = jest.fn().mockResolvedValue(response);
+    postJSONBody(url);
+    await new Promise(setImmediate);
+
+    expect(window.fetch).toBeCalledWith(url, expect.objectContaining({ method: 'POST' }));
+    expect(response.json).toBeCalled();
+  });
+
+  it('should post with a body and get json', () => {
+    postJSONBody(url, { nested: { data: 'test', withArray: [1, 2] } });
+    expect(window.fetch).toBeCalledWith(
+      url,
+      expect.objectContaining({
+        headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
+        body: '{"nested":{"data":"test","withArray":[1,2]}}',
+        method: 'POST',
+      })
     );
   });
 });


### PR DESCRIPTION
There is currently no way of using the request class to send a JSON in the body of the request. This is needed for SC-2114 as a new endpoint requires it.

**Checklist**

* [ ] Functional validation
* [ ] Documentation update
* [x] Update changelog

