### PR TITLE
WWWSC-86 Add possibility to have custom aria-label to Rating component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Allow custom aria attributs in Rating component
+
 ## 1.0.10
 
 - Add POST JSON body request support

--- a/components/ui/Rating.tsx
+++ b/components/ui/Rating.tsx
@@ -23,16 +23,26 @@ import { translate, translateWithParameters } from '../../helpers/l10n';
 import { formatMeasure } from '../../helpers/measures';
 import './Rating.css';
 
-interface Props {
+interface Props extends React.AriaAttributes {
   className?: string;
   muted?: boolean;
   small?: boolean;
   value: string | number | undefined;
 }
 
-export default function Rating({ className, muted = false, small = false, value }: Props) {
+export default function Rating({
+  className,
+  muted = false,
+  small = false,
+  value,
+  ...ariaAttrs
+}: Props) {
   if (value === undefined) {
-    return <span aria-label={translate('metric.no_rating')}>–</span>;
+    return (
+      <span aria-label={translate('metric.no_rating')} {...ariaAttrs}>
+        –
+      </span>
+    );
   }
   const formatted = formatMeasure(value, 'RATING');
   return (
@@ -40,10 +50,11 @@ export default function Rating({ className, muted = false, small = false, value 
       aria-label={translateWithParameters('metric.has_rating_X', formatted)}
       className={classNames(
         'rating',
-        'rating-' + formatted,
+        `rating-${formatted}`,
         { 'rating-small': small, 'rating-muted': muted },
         className
-      )}>
+      )}
+      {...ariaAttrs}>
       {formatted}
     </span>
   );

--- a/components/ui/__tests__/Rating-test.tsx
+++ b/components/ui/__tests__/Rating-test.tsx
@@ -26,9 +26,16 @@ it('renders numeric value', () => {
 });
 
 it('renders string value', () => {
-  expect(shallow(<Rating value="2.0" />)).toMatchSnapshot();
+  expect(shallow(<Rating value="2.0" muted={true} small={true} />)).toMatchSnapshot();
 });
 
 it('renders undefined value', () => {
-  expect(shallow(<Rating value={undefined} />)).toMatchSnapshot();
+  expect(shallow(<Rating value={undefined} muted={true} small={true} />)).toMatchSnapshot();
+});
+
+it('renders with a custom aria-label', () => {
+  expect(shallow(<Rating aria-label="custom" aria-hidden={false} value="2.0" />)).toMatchSnapshot();
+  expect(
+    shallow(<Rating aria-label="custom" aria-hidden={false} value={undefined} />)
+  ).toMatchSnapshot();
 });

--- a/components/ui/__tests__/__snapshots__/Rating-test.tsx.snap
+++ b/components/ui/__tests__/__snapshots__/Rating-test.tsx.snap
@@ -12,7 +12,7 @@ exports[`renders numeric value 1`] = `
 exports[`renders string value 1`] = `
 <span
   aria-label="metric.has_rating_X.B"
-  className="rating rating-B"
+  className="rating rating-B rating-small rating-muted"
 >
   B
 </span>
@@ -21,6 +21,25 @@ exports[`renders string value 1`] = `
 exports[`renders undefined value 1`] = `
 <span
   aria-label="metric.no_rating"
+>
+  –
+</span>
+`;
+
+exports[`renders with a custom aria-label 1`] = `
+<span
+  aria-hidden={false}
+  aria-label="custom"
+  className="rating rating-B"
+>
+  B
+</span>
+`;
+
+exports[`renders with a custom aria-label 2`] = `
+<span
+  aria-hidden={false}
+  aria-label="custom"
 >
   –
 </span>


### PR DESCRIPTION
We need custom aria-label on ratings for the marketing pages.
