### PR TITLE
Add round Avatar optional prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add optional round prop to GenericAvatar
+
 ## 1.0.14
 
 - Allow to opt out of the NavBar limited class

--- a/components/ui/GenericAvatar.tsx
+++ b/components/ui/GenericAvatar.tsx
@@ -24,10 +24,11 @@ import { getTextColor, stringToColor } from '../../helpers/colors';
 interface Props {
   className?: string;
   name: string;
+  round?: boolean;
   size: number;
 }
 
-export default function GenericAvatar({ className, name, size }: Props) {
+export default function GenericAvatar({ className, name, round, size }: Props) {
   const color = stringToColor(name);
 
   let text = '';
@@ -43,6 +44,7 @@ export default function GenericAvatar({ className, name, size }: Props) {
       className={classNames(className, 'rounded')}
       style={{
         backgroundColor: color,
+        borderRadius: round ? '50%' : undefined,
         color: getTextColor(color),
         display: 'inline-block',
         fontSize: Math.min(size / 2, 14),

--- a/components/ui/__tests__/GenericAvatar-test.tsx
+++ b/components/ui/__tests__/GenericAvatar-test.tsx
@@ -23,4 +23,5 @@ import GenericAvatar from '../GenericAvatar';
 
 it('should render properly', () => {
   expect(shallow(<GenericAvatar name="foo" size={40} />)).toMatchSnapshot();
+  expect(shallow(<GenericAvatar name="foo" size={40} round={true} />)).toMatchSnapshot();
 });

--- a/components/ui/__tests__/__snapshots__/GenericAvatar-test.tsx.snap
+++ b/components/ui/__tests__/__snapshots__/GenericAvatar-test.tsx.snap
@@ -6,6 +6,30 @@ exports[`should render properly 1`] = `
   style={
     Object {
       "backgroundColor": "#c68c01",
+      "borderRadius": undefined,
+      "color": "#fff",
+      "display": "inline-block",
+      "fontSize": 14,
+      "fontWeight": "normal",
+      "height": 40,
+      "lineHeight": "40px",
+      "textAlign": "center",
+      "verticalAlign": "top",
+      "width": 40,
+    }
+  }
+>
+  F
+</div>
+`;
+
+exports[`should render properly 2`] = `
+<div
+  className="rounded"
+  style={
+    Object {
+      "backgroundColor": "#c68c01",
+      "borderRadius": "50%",
       "color": "#fff",
       "display": "inline-block",
       "fontSize": 14,


### PR DESCRIPTION
Sonarcloud is going to start using completely rounded avatars in a couple of places inside the New UI. In order to make this easy and clean I added an optional round prop to the GenericAvatar component.

**Checklist**

* [ ] Functional validation
* [ ] Documentation update
* [x] Update changelog

