### PR TITLE
SC-2266 onVersionChange request option returns if request can proceed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 1.0.17
+
 - SC-2266 onVersionChange request option must return a boolean to allow the request to proceed or not
 
 ## 1.0.16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- SC-2266 onVersionChange request option must return a boolean to allow the request to proceed or not
+
 ## 1.0.16
 
 - Bump to eslint-config-sonarqube@0.6.1

--- a/helpers/__tests__/request-test.ts
+++ b/helpers/__tests__/request-test.ts
@@ -19,6 +19,7 @@
  */
 
 import handleRequiredAuthentication from '../handleRequiredAuthentication';
+import { getRequestOptions } from '../init';
 import {
   checkStatus,
   getJSON,
@@ -33,7 +34,6 @@ import {
   postJSONBody,
   requestTryAndRepeatUntil,
 } from '../request';
-import { getRequestOptions } from '../init';
 
 jest.mock('../handleRequiredAuthentication', () => ({ default: jest.fn() }));
 
@@ -336,7 +336,7 @@ describe('checkStatus', () => {
   });
 
   it('should notify when version is changing', async () => {
-    const onVersionChange = jest.fn();
+    const onVersionChange = jest.fn().mockReturnValue(true);
     (getRequestOptions as jest.Mock).mockReturnValue({
       onVersionChange,
     });

--- a/helpers/request.ts
+++ b/helpers/request.ts
@@ -24,7 +24,7 @@ import { getRequestOptions, getUrlContext } from './init';
 import { translate } from './l10n';
 
 export interface RequestOptions {
-  onVersionChange?: VoidFunction;
+  onVersionChange?: () => boolean;
 }
 
 /** Current application version. Can be changed if a newer version is deployed. */
@@ -155,6 +155,7 @@ export function corsRequest(url: string, mode: RequestMode = 'cors'): Request {
 
 function reload() {
   window.location.reload();
+  return false;
 }
 
 function checkApplicationVersion(response: Response): boolean {
@@ -162,8 +163,7 @@ function checkApplicationVersion(response: Response): boolean {
   if (version) {
     if (currentApplicationVersion && currentApplicationVersion !== version) {
       const { onVersionChange = reload } = getRequestOptions();
-      onVersionChange();
-      return false;
+      return onVersionChange();
     } else {
       currentApplicationVersion = version;
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sonar-ui-common",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "description": "Common UI lib for SonarQube and SonarCloud",
   "repository": "SonarSource/sonar-ui-common",
   "license": "LGPL-3.0",


### PR DESCRIPTION
On SC we want to let users keep using the app even if the api version changed, that's why we need the onVersionChange request option to also handle this

**Checklist**

* [ ] Functional validation
* [ ] Documentation update
* [ ] Update changelog

