### PR TITLE
SC-2330 Add vertical radiocard style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+ - SC-2330 Add vertical RadioCard style
+
 ## 1.0.17
 
 - SC-2266 onVersionChange request option must return a boolean to allow the request to proceed or not

--- a/components/controls/RadioCard.css
+++ b/components/controls/RadioCard.css
@@ -53,6 +53,11 @@
   outline: none;
 }
 
+.radio-card-vertical {
+  width: 100%;
+  min-height: auto;
+}
+
 .radio-card-actionable {
   cursor: pointer;
 }
@@ -64,6 +69,20 @@
 
 .radio-card-actionable.selected {
   border-color: var(--darkBlue);
+}
+
+/*
+ * Disabled transform property because it moves the element to a new stacking context
+ * creating z-index conflicts with other components.
+ * This is a problem with a vertical list of RadioCards where a select might be above another RadioCard
+ */
+.radio-card-actionable.radio-card-vertical:not(.disabled):hover {
+  box-shadow: none;
+  transform: none;
+}
+
+.radio-card-actionable.radio-card-vertical:not(.selected):not(.disabled):hover {
+  border-color: var(--lightBlue);
 }
 
 .radio-card-actionable.selected .radio-card-recommended {

--- a/components/controls/RadioCard.tsx
+++ b/components/controls/RadioCard.tsx
@@ -37,17 +37,31 @@ interface Props extends RadioCardProps {
   recommended?: string;
   title: React.ReactNode;
   titleInfo?: React.ReactNode;
+  vertical?: boolean;
 }
 
 export default function RadioCard(props: Props) {
-  const { className, disabled, onClick, recommended, selected, titleInfo } = props;
+  const {
+    className,
+    disabled,
+    onClick,
+    recommended,
+    selected,
+    titleInfo,
+    vertical = false,
+  } = props;
   const isActionable = Boolean(onClick);
   return (
     <div
       aria-checked={selected}
       className={classNames(
         'radio-card',
-        { 'radio-card-actionable': isActionable, disabled, selected },
+        {
+          'radio-card-actionable': isActionable,
+          'radio-card-vertical': vertical,
+          disabled,
+          selected,
+        },
         className
       )}
       onClick={isActionable && !disabled ? onClick : undefined}

--- a/components/controls/__tests__/RadioCard-test.tsx
+++ b/components/controls/__tests__/RadioCard-test.tsx
@@ -30,6 +30,18 @@ it('should render correctly', () => {
       </RadioCard>
     )
   ).toMatchSnapshot();
+
+  expect(
+    shallow(
+      <RadioCard
+        recommended="Recommended for you"
+        title="Radio Card Vertical"
+        titleInfo="info"
+        vertical={true}>
+        <div>content</div>
+      </RadioCard>
+    )
+  ).toMatchSnapshot();
 });
 
 it('should be actionable', () => {

--- a/components/controls/__tests__/__snapshots__/RadioCard-test.tsx.snap
+++ b/components/controls/__tests__/__snapshots__/RadioCard-test.tsx.snap
@@ -126,3 +126,47 @@ exports[`should render correctly 1`] = `
   </div>
 </div>
 `;
+
+exports[`should render correctly 2`] = `
+<div
+  className="radio-card radio-card-vertical"
+  role="radio"
+  tabIndex={0}
+>
+  <h2
+    className="radio-card-header big-spacer-bottom"
+  >
+    <span
+      className="display-flex-center link-radio"
+    >
+      Radio Card Vertical
+    </span>
+    info
+  </h2>
+  <div
+    className="radio-card-body"
+  >
+    <div>
+      content
+    </div>
+  </div>
+  <div
+    className="radio-card-recommended"
+  >
+    <RecommendedIcon
+      className="spacer-right"
+    />
+    <FormattedMessage
+      defaultMessage="Recommended for you"
+      id="Recommended for you"
+      values={
+        Object {
+          "recommended": <strong>
+            recommended
+          </strong>,
+        }
+      }
+    />
+  </div>
+</div>
+`;


### PR DESCRIPTION
With this vertical option we introduce a simple design with no minimum-height, full width and using a light border color on hover with no shadow or translation.

**Checklist**

* [x] Functional validation
* [x] Documentation update
* [x] Update changelog

