### PR TITLE
SC-2335 Add not computed QG level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- SC-2335 Add not computed QG level
+
 ## 1.0.22
 
 - SONAR-13758 Add new code legend to Activity Chart

--- a/components/ui/Level.css
+++ b/components/ui/Level.css
@@ -76,3 +76,7 @@ a > .level:hover {
 .level-NONE {
   background-color: var(--gray71);
 }
+
+.level-NOT_COMPUTED {
+  background-color: var(--gray40);
+}


### PR DESCRIPTION
Adding an extra QG Level for not computed as it is important for SC to show the user that it wasn't computed because of missing code period.

https://jira.sonarsource.com/browse/SC-2335

**Checklist**

* [ ] Functional validation
* [ ] Documentation update
* [ ] Update changelog

