### PR TITLE
SONAR-12698 Increase tooltip font size for readability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- SONAR-12698 Tooltip font size should be 13px for readability
+
 ## 1.0.23
 
 - SC-2335 Add not computed QG level

--- a/components/controls/Tooltip.css
+++ b/components/controls/Tooltip.css
@@ -23,7 +23,7 @@
   display: block;
   height: auto;
   box-sizing: border-box;
-  font-size: var(--smallFontSize);
+  font-size: var(--baseFontSize);
   font-weight: 300;
   line-height: 1.5;
   animation: fadeIn 0.3s forwards;


### PR DESCRIPTION
## Before

<img width="648" alt="Screenshot 2020-10-01 at 11 02 57" src="https://user-images.githubusercontent.com/45544358/94789819-b5ec1f00-03d5-11eb-87cd-1fa22a72ac2b.png">

## After

![](https://images-eu.ssl-images-amazon.com/images/I/81PyTDtJlnL.png)

---

## After for real

<img width="557" alt="Screenshot 2020-10-01 at 11 03 04" src="https://user-images.githubusercontent.com/45544358/94789834-bab0d300-03d5-11eb-8916-40256fcaba42.png">
