### PR TITLE
SONAR-12996 Make copy to clipboard icon button more accessible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - SONAR-12698 Tooltip font size should be 13px for readability
+- SONAR-12996 Copy-to-clipboard icon button is not accessible
 
 ## 1.0.23
 

--- a/components/controls/__tests__/__snapshots__/clipboard-test.tsx.snap
+++ b/components/controls/__tests__/__snapshots__/clipboard-test.tsx.snap
@@ -41,6 +41,7 @@ exports[`ClipboardButton should render a custom label if provided 1`] = `
 
 exports[`ClipboardIconButton should display correctly 1`] = `
 <ButtonIcon
+  aria-label="copy_to_clipboard"
   className="no-select"
   data-clipboard-text="foo"
   innerRef={[Function]}

--- a/components/controls/clipboard.tsx
+++ b/components/controls/clipboard.tsx
@@ -122,16 +122,19 @@ export function ClipboardButton({ className, children, copyValue }: ButtonProps)
 }
 
 interface IconButtonProps {
+  'aria-label'?: string;
   className?: string;
   copyValue: string;
 }
 
-export function ClipboardIconButton({ className, copyValue }: IconButtonProps) {
+export function ClipboardIconButton(props: IconButtonProps) {
+  const { className, copyValue } = props;
   return (
     <ClipboardBase>
       {({ setCopyButton, copySuccess }) => {
         return (
           <ButtonIcon
+            aria-label={props['aria-label'] ?? translate('copy_to_clipboard')}
             className={classNames('no-select', className)}
             data-clipboard-text={copyValue}
             innerRef={setCopyButton}


### PR DESCRIPTION
I'm happy to be challenged in declaring an `aria-label` prop explicitly. I know we discussed this before in regards to icon buttons.